### PR TITLE
Add alias for types folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Run `npm install` or `npm ci` before using `npm run lint` or `npm run build`. Th
 - `npm run lint` – run ESLint
 - `npm run preview` – serve the production build locally
 
+## Path Aliases
+
+You can import utility modules and shared types using the configured aliases:
+
+- `@utility/*` → `src/utility/*`
+- `@types/*` → `src/types/*`
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
-      "@utility/*": ["src/utility/*"]
+      "@utility/*": ["src/utility/*"],
+      "@types/*": ["src/types/*"]
     }
   },
   "include": ["src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
+      '@types': fileURLToPath(new URL('./src/types', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- create `@types` path alias in tsconfig
- expose new alias in Vite config
- document available path aliases

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68723a8e63ec8332b383030504db47f5