### PR TITLE
Fix build by defining CleanUp locally

### DIFF
--- a/src/utility/trackedState.ts
+++ b/src/utility/trackedState.ts
@@ -1,5 +1,6 @@
-import type { CleanUp } from '@types/utility'
 import { logDebug } from '@utility/logMessage.ts'
+
+export type CleanUp = () => void
 
 export type TrackValueSubscriber = () => void
 export type OnValueChangedCallback<T> = (newValue: T, oldValue: T) => void


### PR DESCRIPTION
## Summary
- avoid importing type-only modules
- declare `CleanUp` type directly in `trackedState.ts`

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872477fd1e0833293cbdccddaacff6d