### PR TITLE
Fix logMessage import paths

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { logDebug } from '@utility/logMessage.ts'
+import { logDebug } from '@utility/logMessage'
 
 logDebug('Application starting...')
 

--- a/src/utility/loadJsonResource.ts
+++ b/src/utility/loadJsonResource.ts
@@ -1,5 +1,5 @@
 import { ZodType } from 'zod'
-import { logDebug } from '@utility/logMessage.ts'
+import { logDebug } from '@utility/logMessage'
 
 export async function loadJsonResource<T>(url: string, schema: ZodType<T>): Promise<T> {
   logDebug('Fetching JSON resource from {0}', url)

--- a/src/utility/trackedState.ts
+++ b/src/utility/trackedState.ts
@@ -1,5 +1,5 @@
 
-import { logDebug } from '@utility/logMessage.ts'
+import { logDebug } from '@utility/logMessage'
 
 export type CleanUp = () => void
 


### PR DESCRIPTION
## Summary
- update logMessage imports to use extensionless path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687258b4de748332af5677a37809bc6c