### PR TITLE
Add data path alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ Run `npm install` or `npm ci` before using `npm run lint` or `npm run build`. Th
 You can import utility modules and shared types using the configured aliases:
 
 - `@utility/*` → `src/utility/*`
+- `@data/*` → `src/data/*`
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import './index.css'
 import App from './App.tsx'
 import { logDebug } from '@utility/logMessage.ts'
 import { loadJsonResource } from '@utility/loadJsonResource.ts'
-import { gameSchema, type Game } from './data/game.ts'
+import { gameSchema, type Game } from '@data/game'
 
 logDebug('Application starting...')
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
-      "@utility/*": ["src/utility/*"]
+      "@utility/*": ["src/utility/*"],
+      "@data/*": ["src/data/*"]
     }
   },
   "include": ["src"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
+      '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- add `@data` path alias in TypeScript and Vite config
- document the alias in README
- update import in `src/main.tsx`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872681474548332b6d1e69917c3b5b1