### PR TITLE
Point Vite static copy to external data directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,20 +1,28 @@
-import { defineConfig } from 'vite'
+import { defineConfig, normalizePath } from 'vite'
 import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
+import path from 'node:path'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 // https://vite.dev/config/
+const marketValueDataDir = fileURLToPath(new URL('../market-value/data', import.meta.url))
+
 export default defineConfig({
   plugins: [
     react(),
     viteStaticCopy({
       targets: [
         {
-          src: 'data/**/*',
-          dest: '.',
+          src: normalizePath(path.join(marketValueDataDir, '**/*')),
+          dest: 'data',
+          rename: (_name, _ext, fullPath) => {
+            const rel = normalizePath(path.relative(marketValueDataDir, fullPath))
+            return rel
+          },
         },
       ],
-      structured: true,
+      structured: false,
+      silent: true,
     }),
   ],
   resolve: {


### PR DESCRIPTION
## Summary
- move static data source outside of repo
- handle the relative paths with a rename callback
- silence missing file errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687286f557cc83329136e7c0893f8ef9