### PR TITLE
Add utility tests

### DIFF
--- a/src/utility/__tests__/logMessage.test.ts
+++ b/src/utility/__tests__/logMessage.test.ts
@@ -1,0 +1,19 @@
+import { logMessage, LogLevel } from '@utility/logMessage'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// ensure console methods are restored after each test
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('logMessage', () => {
+  it('formats message and logs using console', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    const obj = { foo: 'bar' }
+    const result = logMessage(LogLevel.info, 'hello {0} {1}', 'world', obj)
+
+    expect(result).toBe('hello world %o')
+    expect(spy).toHaveBeenCalledWith('\x1B[30m' + result, obj)
+  })
+})

--- a/src/utility/__tests__/trackedState.test.ts
+++ b/src/utility/__tests__/trackedState.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { TrackedValue } from '@utility/trackedState'
+
+vi.mock('@utility/logMessage', () => ({
+  logDebug: vi.fn()
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('TrackedValue', () => {
+  it('notifies subscribers and callback on value change', () => {
+    const callback = vi.fn()
+    const tracked = new TrackedValue<number>('score', 1, callback)
+
+    const subscriber = vi.fn()
+    const unsubscribe = tracked.subscribe(subscriber)
+
+    tracked.value = 2
+
+    expect(callback).toHaveBeenCalledWith(2, 1)
+    expect(subscriber).toHaveBeenCalledTimes(1)
+
+    subscriber.mockClear()
+    callback.mockClear()
+
+    // setting same value should not trigger callbacks
+    tracked.value = 2
+    expect(callback).not.toHaveBeenCalled()
+    expect(subscriber).not.toHaveBeenCalled()
+
+    // unsubscribe and change again
+    unsubscribe()
+    tracked.value = 3
+    expect(subscriber).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add a unit test for `logMessage` console output
- add tests for `TrackedValue` subscriber notifications

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6873566d462c833295c4e4374ed51685