### PR TITLE
Add messageBus unit tests

### DIFF
--- a/src/utility/__tests__/messageBus.test.ts
+++ b/src/utility/__tests__/messageBus.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('@utility/logMessage', () => ({
+  logDebug: vi.fn(),
+  logWarning: vi.fn(),
+}))
+
+import { MessageBus } from '@utility/messageBus'
+import { logWarning } from '@utility/logMessage'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('MessageBus', () => {
+  it('delivers messages to registered listeners', () => {
+    const onEmpty = vi.fn()
+    const bus = new MessageBus(onEmpty)
+    const handler = vi.fn()
+    bus.registerMessageListener('test', handler)
+
+    const msg = { message: 'test', payload: 'payload' }
+    bus.postMessage(msg)
+
+    expect(handler).toHaveBeenCalledWith(msg)
+    expect(onEmpty).toHaveBeenCalled()
+  })
+
+  it('logs warning when no listener is registered', () => {
+    const onEmpty = vi.fn()
+    const bus = new MessageBus(onEmpty)
+
+    const msg = { message: 'missing', payload: 'foo' }
+    bus.postMessage(msg)
+
+    expect(logWarning).toHaveBeenCalled()
+    expect(onEmpty).toHaveBeenCalled()
+  })
+
+  it('processes queued messages when re-enabled', () => {
+    const onEmpty = vi.fn()
+    const bus = new MessageBus(onEmpty)
+    const handler = vi.fn()
+    bus.registerMessageListener('queued', handler)
+
+    bus.disableEmptyQueueAfterPost()
+    bus.postMessage({ message: 'queued', payload: 42 })
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(onEmpty).not.toHaveBeenCalled()
+
+    bus.enableEmptyQueueAfterPost()
+
+    expect(handler).toHaveBeenCalledWith({ message: 'queued', payload: 42 })
+    expect(onEmpty).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `MessageBus`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68735cf0846c8332b12e7eaafcb6a860