### PR TITLE
Move tests after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,5 @@ jobs:
       - run: npm ci
       - run: npm run lint --if-present
       - run: npm run build --if-present
+      - run: npm test -- --run
 


### PR DESCRIPTION
## Summary
- swap the order of build and test steps in CI so tests run after the build

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68735cda1f08833282a7508353462ee1