### PR TITLE
Rename method and update calls

### DIFF
--- a/src/utility/messageBus.ts
+++ b/src/utility/messageBus.ts
@@ -25,7 +25,7 @@ export class MessageBus implements IMessageBus {
         this.queue.push(message)
         logDebug('EmptyQueueAfterPost: {0}', this.emptyQueueAfterPost)
         if (this.emptyQueueAfterPost === 0) {
-            this.EmptyQueue()
+            this.emptyQueue()
         }
     }
 
@@ -35,7 +35,7 @@ export class MessageBus implements IMessageBus {
 
     public enableEmptyQueueAfterPost(): void {
         this.emptyQueueAfterPost = Math.max(0, this.emptyQueueAfterPost - 1)
-        this.EmptyQueue()
+        this.emptyQueue()
     }
 
     public registerMessageListener(message: string, handler: (message: Message) => void): CleanUp {
@@ -69,7 +69,7 @@ export class MessageBus implements IMessageBus {
         listeners.forEach(listener => listener.handler(message))
     }
 
-    public EmptyQueue(): void {
+    public emptyQueue(): void {
         if (this.emptyingQueue || this.queue.length === 0) return
         this.emptyingQueue = true
         try {


### PR DESCRIPTION
## Summary
- rename `EmptyQueue` method to `emptyQueue` in `MessageBus`
- update all internal calls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873631121f0833299d488fa92d185b5