### PR TITLE
Fix CleanUp import

### DIFF
--- a/src/utility/trackedState.ts
+++ b/src/utility/trackedState.ts
@@ -1,7 +1,6 @@
 
 import { logDebug } from '@utility/logMessage'
-
-export type CleanUp = () => void
+import { type CleanUp } from './types'
 
 export type TrackValueSubscriber = () => void
 export type OnValueChangedCallback<T> = (newValue: T, oldValue: T) => void


### PR DESCRIPTION
## Summary
- remove duplicate `CleanUp` type in `trackedState`
- import shared `CleanUp` type from `types.ts`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873631cb1f08332b5972386b43854a7