### PR TITLE
Fix linter after moving tests

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -20,7 +20,15 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@utility/*": ["src/utility/*"],
+      "@data/*": ["src/data/*"]
+    }
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "test/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- include test folder in tsconfig.node.json
- add path aliases so ESLint can resolve imports

## Testing
- `npm run lint`
- `npm run test` *(cancelled once running)*

------
https://chatgpt.com/codex/tasks/task_e_687367ae774483329777c50525737900