### PR TITLE
Add alias for app folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Run `npm install` or `npm ci` before using `npm run lint` or `npm run build`. Th
 
 ## Path Aliases
 
-You can import utility modules and shared types using the configured aliases:
+You can import modules using the configured aliases:
 
 - `@utility/*` → `src/utility/*`
 - `@data/*` → `src/data/*`
+- `@app/*` → `src/app/*`
 
 ## Testing
 

--- a/src/app/game.tsx
+++ b/src/app/game.tsx
@@ -1,4 +1,4 @@
-interface GameProps {}
+type GameProps = Record<string, never>
 
 const Game: React.FC<GameProps> = (): React.JSX.Element => {
     return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import './index.css'
 import { logDebug } from '@utility/logMessage.ts'
 import { loadJsonResource } from '@utility/loadJsonResource.ts'
 import { gameSchema, type Game } from '@data/load/game'
-import App from './app/game.tsx'
+import App from '@app/game.tsx'
 
 logDebug('Application starting...')
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,7 +25,8 @@
     "baseUrl": ".",
     "paths": {
       "@utility/*": ["src/utility/*"],
-      "@data/*": ["src/data/*"]
+      "@data/*": ["src/data/*"],
+      "@app/*": ["src/app/*"]
     }
   },
   "include": ["src"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -24,7 +24,8 @@
     "baseUrl": ".",
     "paths": {
       "@utility/*": ["src/utility/*"],
-      "@data/*": ["src/data/*"]
+      "@data/*": ["src/data/*"],
+      "@app/*": ["src/app/*"]
     }
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     alias: {
       '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
       '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
+      '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
     },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     alias: {
       '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
       '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
+      '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- expose `src/app` as `@app` alias for dev, tests and build
- update import path in `src/main.tsx`
- adjust lint rule violation in `src/app/game.tsx`
- document new alias

## Testing
- `npm run lint`
- `npm run test` *(stopped via `CTRL+C` after success)*

------
https://chatgpt.com/codex/tasks/task_e_6873b82cfdc08332aef00aa102dfa009