### PR TITLE
Add sample game support with configurable game directory

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GAME_DIR=sample-game

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ This project uses [Vite](https://vitejs.dev/) with React and TypeScript. Hot mod
 
 Run `npm install` or `npm ci` before using `npm run lint` or `npm run build`. These commands need the `node_modules` folder generated from `package-lock.json`.
 
+The development server loads game data from the folder defined by the `GAME_DIR`
+environment variable. A default `.env` file is provided pointing to the included
+`sample-game` directory, so `npm run dev` works out of the box. To use a different
+game located elsewhere on your machine, create an `.env.local` file and set
+`GAME_DIR` to the desired path.
+
 ## Available Scripts
 
 - `npm run dev` – start the development server

--- a/sample-game/game.json
+++ b/sample-game/game.json
@@ -1,0 +1,5 @@
+{
+  "title": "Sample Game",
+  "description": "A sample game for development",
+  "modules": []
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,35 +1,41 @@
-import { defineConfig, normalizePath } from 'vite'
+import { defineConfig, loadEnv, normalizePath } from 'vite'
 import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
 import path from 'node:path'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 // https://vite.dev/config/
-const marketValueDataDir = fileURLToPath(new URL('../market-value/data', import.meta.url))
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const gameDir = env.GAME_DIR || 'sample-game'
+  const gameDataDir = fileURLToPath(new URL(gameDir, import.meta.url))
 
-export default defineConfig({
-  plugins: [
-    react(),
-    viteStaticCopy({
-      targets: [
-        {
-          src: normalizePath(path.join(marketValueDataDir, '**/*')),
-          dest: 'data',
-          rename: (_name, _ext, fullPath) => {
-            const rel = normalizePath(path.relative(marketValueDataDir, fullPath))
-            return rel
+  return {
+    plugins: [
+      react(),
+      viteStaticCopy({
+        targets: [
+          {
+            src: normalizePath(path.join(gameDataDir, '**/*')),
+            dest: 'data',
+            rename: (_name, _ext, fullPath) => {
+              const rel = normalizePath(path.relative(gameDataDir, fullPath))
+              return rel
+            },
           },
-        },
-      ],
-      structured: false,
-      silent: true,
-    }),
-  ],
-  resolve: {
-    alias: {
-      '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
-      '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
-      '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
+        ],
+        structured: false,
+        silent: true,
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
+        '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
+        '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
+      },
     },
-  },
+  }
 })
+
+


### PR DESCRIPTION
## Summary
- add `sample-game` with a basic `game.json`
- expose a `GAME_DIR` variable through `.env`
- update Vite config to copy data from `GAME_DIR`
- document how to switch games

## Testing
- `npm run test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6876b45370888332919cf1c2d72ecf8c