### PR TITLE
Add schemas for sample game modules

### DIFF
--- a/src/data/load/component.ts
+++ b/src/data/load/component.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+
+export const buttonSchema = z.object({
+    label: z.string(),
+    action: z.string(),
+})
+
+export const gameMenuDataSchema = z.object({
+    type: z.literal('game-menu'),
+    buttons: z.array(buttonSchema),
+})
+
+export const componentDataSchema = z.discriminatedUnion('type', [gameMenuDataSchema])
+
+export const componentSchema = z.object({
+    type: z.literal('component'),
+    description: z.string(),
+    data: componentDataSchema,
+})
+
+export type Button = z.infer<typeof buttonSchema>
+export type GameMenuData = z.infer<typeof gameMenuDataSchema>
+export type ComponentData = z.infer<typeof componentDataSchema>
+export type ComponentModule = z.infer<typeof componentSchema>

--- a/src/data/load/module.ts
+++ b/src/data/load/module.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod'
+import { componentSchema } from './component'
+import { pageSchema } from './page'
 
-export const moduleSchema = z.object({
-  type: z.enum(['component', 'page']),
-  description: z.string(),
-})
+export const moduleSchema = z.discriminatedUnion('type', [componentSchema, pageSchema])
 
 export type Module = z.infer<typeof moduleSchema>

--- a/src/data/load/page.ts
+++ b/src/data/load/page.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod'
+import { screenSchema } from './screen'
+
+export const gridPositionSchema = z.object({
+    row: z.number(),
+    column: z.number(),
+    rowSpan: z.number().optional(),
+    columnSpan: z.number().optional(),
+})
+
+export const pageComponentSchema = z.object({
+    type: z.string(),
+    position: gridPositionSchema,
+})
+
+export const pageSchema = z.object({
+    type: z.literal('page'),
+    description: z.string(),
+    screen: screenSchema,
+    components: z.array(pageComponentSchema),
+})
+
+export type GridPosition = z.infer<typeof gridPositionSchema>
+export type PageComponent = z.infer<typeof pageComponentSchema>
+export type PageModule = z.infer<typeof pageSchema>

--- a/src/data/load/screen.ts
+++ b/src/data/load/screen.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const gridScreenSchema = z.object({
+    type: z.literal('grid'),
+    rows: z.number(),
+    columns: z.number(),
+})
+
+export const screenSchema = z.discriminatedUnion('type', [gridScreenSchema])
+
+export type GridScreen = z.infer<typeof gridScreenSchema>
+export type Screen = z.infer<typeof screenSchema>


### PR DESCRIPTION
## Summary
- extend data models to match sample game
- add `Component`, `Page` and `Screen` schemas
- make `moduleSchema` a discriminated union

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6876c7c74a0c8332b27cbb0c98f2ec9e