### PR TITLE
Add translation loading

### DIFF
--- a/sample-game/translations/en/index.json
+++ b/sample-game/translations/en/index.json
@@ -1,6 +1,6 @@
 {
     "name": "English",
-    "translattions": {
+    "translations": {
         "MENU.START-GAME": "Start Game",
         "MENU.SETTINGS": "Settings",
         "MENU.EXIT": "Exit"

--- a/src/data/game/game.ts
+++ b/src/data/game/game.ts
@@ -1,7 +1,9 @@
 import type { Module } from './module'
+import type { Translations } from './translation'
 
 export interface GameData {
     title: string
     description: string
     modules: Record<string, Module>
+    translations: Translations
 }

--- a/src/data/game/translation.ts
+++ b/src/data/game/translation.ts
@@ -1,0 +1,8 @@
+export interface LanguageData {
+    name: string
+    translations: Record<string, string>
+}
+
+export interface Translations {
+    languages: Record<string, LanguageData>
+}

--- a/src/data/load/game.ts
+++ b/src/data/load/game.ts
@@ -4,6 +4,7 @@ export const gameSchema = z.object({
   title: z.string(),
   description: z.string(),
   modules: z.array(z.string()),
+  translations: z.array(z.string()),
 })
 
 export type Game = z.infer<typeof gameSchema>

--- a/src/data/load/translation.ts
+++ b/src/data/load/translation.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const translationsIndexSchema = z.object({
+    languages: z.array(z.string())
+})
+
+export const languageDataSchema = z.object({
+    name: z.string(),
+    translations: z.record(z.string(), z.string())
+})
+
+export type TranslationsIndex = z.infer<typeof translationsIndexSchema>
+export type LanguageData = z.infer<typeof languageDataSchema>

--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -39,6 +39,12 @@ export class GameEngine implements IGameEngine {
         logInfo('Game engine started')
     }
 
+    translate(key: string, language: string): string {
+        const lang = this.game.translations.languages[language]
+        if (!lang) return key
+        return lang.translations[key] ?? key
+    }
+
     get State(): ITrackedValue<GameEngineState> {
         return this._state
     }

--- a/src/engine/type.ts
+++ b/src/engine/type.ts
@@ -10,5 +10,6 @@ export type GameEngineState = typeof GameEngineState[keyof typeof GameEngineStat
 export interface IGameEngine {
     start(): void
     get State(): ITrackedValue<GameEngineState>
+    translate(key: string, language: string): string
 }
 

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -2,14 +2,17 @@ import { loadJsonResource } from '@utility/loadJsonResource'
 import { gameSchema } from '@data/load/game'
 import { moduleSchema } from '@data/load/module'
 import { componentSchema } from '@data/load/component'
+import { translationsIndexSchema, languageDataSchema } from '@data/load/translation'
 import type { GameData } from '@data/game/game'
 import type { Module } from '@data/game/module'
 import type { ComponentModule } from '@data/game/component'
 import type { PageModule, PageComponent } from '@data/game/page'
+import type { Translations, LanguageData } from '@data/game/translation'
 
 const BASE_PATH = '/data'
 
 const moduleCache: Map<string, Module> = new Map()
+const translationCache: Map<string, LanguageData> = new Map()
 
 export async function loadGameData(basePath: string = BASE_PATH): Promise<GameData> {
     const gameLoad = await loadJsonResource(`${basePath}/game.json`, gameSchema)
@@ -19,10 +22,17 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
         modules[m] = await loadModule(m, basePath)
     }
 
+    const translations: Translations = { languages: {} }
+    for (const t of gameLoad.translations) {
+        const data = await loadTranslations(t, basePath)
+        Object.assign(translations.languages, data.languages)
+    }
+
     return {
         title: gameLoad.title,
         description: gameLoad.description,
-        modules
+        modules,
+        translations
     }
 }
 
@@ -75,5 +85,26 @@ export async function loadComponentModule(type: string, basePath: string = BASE_
     }
 
     moduleCache.set(path, result)
+    return result
+}
+
+export async function loadTranslations(path: string, basePath: string = BASE_PATH): Promise<Translations> {
+    const index = await loadJsonResource(`${basePath}/${path}/index.json`, translationsIndexSchema)
+    const languages: Record<string, LanguageData> = {}
+    for (const lang of index.languages) {
+        languages[lang] = await loadLanguage(lang, path, basePath)
+    }
+    return { languages }
+}
+
+export async function loadLanguage(lang: string, translationsPath: string, basePath: string = BASE_PATH): Promise<LanguageData> {
+    const cacheKey = `${translationsPath}/${lang}`
+    const cached = translationCache.get(cacheKey)
+    if (cached) {
+        return cached
+    }
+    const data = await loadJsonResource(`${basePath}/${translationsPath}/${lang}/index.json`, languageDataSchema)
+    const result: LanguageData = { name: data.name, translations: { ...data.translations } }
+    translationCache.set(cacheKey, result)
     return result
 }


### PR DESCRIPTION
## Summary
- add translation schema and game interfaces
- load translations in loader
- expose translation API via `GameEngine`
- fix sample language index

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run test -- --run --reporter=dot`


------
https://chatgpt.com/codex/tasks/task_e_68774b10fbd083328bcafe2a4f8d7164