### PR TITLE
Update game schema with start page and version

### DIFF
--- a/src/data/game/game.ts
+++ b/src/data/game/game.ts
@@ -4,6 +4,8 @@ import type { Translations } from './translation'
 export interface GameData {
     title: string
     description: string
+    version: string
+    startPage: string
     modules: Record<string, Module>
     translations: Translations
 }

--- a/src/data/load/game.ts
+++ b/src/data/load/game.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 export const gameSchema = z.object({
   title: z.string(),
   description: z.string(),
+  version: z.string(),
+  startPage: z.string(),
   modules: z.array(z.string()),
   translations: z.array(z.string()),
 })

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -31,6 +31,8 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
     return {
         title: gameLoad.title,
         description: gameLoad.description,
+        version: gameLoad.version,
+        startPage: gameLoad.startPage,
         modules,
         translations
     }


### PR DESCRIPTION
## Summary
- support `startPage` and `version` in game metadata
- load the new fields when parsing `game.json`

## Testing
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6877b89364888332abbc9bb51be84b2e