### PR TITLE
Add support for src resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ You can import modules using the configured aliases:
 - `@utility/*` → `src/utility/*`
 - `@data/*` → `src/data/*`
 - `@app/*` → `src/app/*`
+- `@loader/*` → `src/loader/*`
+- `@resources/*` → `src/resources/*`
 
 ## Testing
 

--- a/src/resources/example.json
+++ b/src/resources/example.json
@@ -1,0 +1,1 @@
+{"message": "Hello from src/resources"}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,7 +27,8 @@
       "@utility/*": ["src/utility/*"],
       "@data/*": ["src/data/*"],
       "@app/*": ["src/app/*"],
-      "@loader/*": ["src/loader/*"]
+      "@loader/*": ["src/loader/*"],
+      "@resources/*": ["src/resources/*"]
     }
   },
   "include": ["src"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -26,7 +26,8 @@
       "@utility/*": ["src/utility/*"],
       "@data/*": ["src/data/*"],
       "@app/*": ["src/app/*"],
-      "@loader/*": ["src/loader/*"]
+      "@loader/*": ["src/loader/*"],
+      "@resources/*": ["src/resources/*"]
     }
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const gameDir = env.GAME_DIR || 'sample-game'
   const gameDataDir = fileURLToPath(new URL(gameDir, import.meta.url))
+  const resourcesDir = fileURLToPath(new URL('./src/resources', import.meta.url))
 
   return {
     plugins: [
@@ -23,6 +24,14 @@ export default defineConfig(({ mode }) => {
               return rel
             },
           },
+          {
+            src: normalizePath(path.join(resourcesDir, '**/*')),
+            dest: 'resources',
+            rename: (_name, _ext, fullPath) => {
+              const rel = normalizePath(path.relative(resourcesDir, fullPath))
+              return rel
+            },
+          },
         ],
         structured: false,
         silent: true,
@@ -34,6 +43,7 @@ export default defineConfig(({ mode }) => {
         '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
         '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
         '@loader': fileURLToPath(new URL('./src/loader', import.meta.url)),
+        '@resources': fileURLToPath(new URL('./src/resources', import.meta.url)),
       },
     },
   }


### PR DESCRIPTION
## Summary
- copy files from `src/resources` to `dist/resources`
- expose new `@resources` path alias
- document new alias

## Testing
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877dd10f618833280f2b111dc835fd1