### PR TITLE
Load virtual input data

### DIFF
--- a/src/data/game/game.ts
+++ b/src/data/game/game.ts
@@ -1,5 +1,6 @@
 import type { Module } from './module'
 import type { Translations } from './translation'
+import type { VirtualKey, VirtualInput } from './virtualInput'
 
 export interface GameData {
     title: string
@@ -8,4 +9,6 @@ export interface GameData {
     startPage: string
     modules: Record<string, Module>
     translations: Translations
+    virtualKeys: Record<string, VirtualKey>
+    virtualInputs: Record<string, VirtualInput>
 }

--- a/src/data/load/game.ts
+++ b/src/data/load/game.ts
@@ -7,6 +7,7 @@ export const gameSchema = z.object({
   startPage: z.string(),
   modules: z.array(z.string()),
   translations: z.array(z.string()),
+  inputs: z.array(z.string()).optional(),
 })
 
 export type Game = z.infer<typeof gameSchema>

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -3,16 +3,20 @@ import { gameSchema } from '@data/load/game'
 import { moduleSchema } from '@data/load/module'
 import { componentSchema } from '@data/load/component'
 import { translationsIndexSchema, languageDataSchema } from '@data/load/translation'
+import { VirtualKeysSchema, VirtualInputsSchema } from '@data/load/virtualInput'
 import type { GameData } from '@data/game/game'
 import type { Module } from '@data/game/module'
 import type { ComponentModule } from '@data/game/component'
 import type { PageModule, PageComponent } from '@data/game/page'
 import type { Translations, LanguageData } from '@data/game/translation'
+import type { VirtualKey, VirtualInput } from '@data/game/virtualInput'
 
 const BASE_PATH = '/data'
+const RESOURCE_PATH = '/resources'
 
 const moduleCache: Map<string, Module> = new Map()
 const translationCache: Map<string, LanguageData> = new Map()
+const virtualKeyCache: Map<string, VirtualKey> = new Map()
 
 export async function loadGameData(basePath: string = BASE_PATH): Promise<GameData> {
     const gameLoad = await loadJsonResource(`${basePath}/game.json`, gameSchema)
@@ -28,13 +32,19 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
         Object.assign(translations.languages, data.languages)
     }
 
+    const inputPaths = gameLoad.inputs ?? []
+    const virtualKeys = await loadVirtualKeys(inputPaths, basePath)
+    const virtualInputs = await loadVirtualInputs(inputPaths, virtualKeys, basePath)
+
     return {
         title: gameLoad.title,
         description: gameLoad.description,
         version: gameLoad.version,
         startPage: gameLoad.startPage,
         modules,
-        translations
+        translations,
+        virtualKeys,
+        virtualInputs
     }
 }
 
@@ -108,5 +118,65 @@ export async function loadLanguage(lang: string, translationsPath: string, baseP
     const data = await loadJsonResource(`${basePath}/${translationsPath}/${lang}/index.json`, languageDataSchema)
     const result: LanguageData = { name: data.name, translations: { ...data.translations } }
     translationCache.set(cacheKey, result)
+    return result
+}
+
+export async function loadVirtualKeys(paths: string[], basePath: string = BASE_PATH, resourcesBase: string = RESOURCE_PATH): Promise<Record<string, VirtualKey>> {
+    const result: Record<string, VirtualKey> = {}
+
+    const mergeKeys = (keys: Array<{ virtualKey: string; keyCode: string; ctrl?: boolean; shift?: boolean; alt?: boolean }>) => {
+        keys.forEach(k => {
+            const key: VirtualKey = {
+                virtualKey: k.virtualKey,
+                keyCode: k.keyCode,
+                ctrl: k.ctrl ?? false,
+                shift: k.shift ?? false,
+                alt: k.alt ?? false,
+            }
+            result[key.virtualKey] = key
+            virtualKeyCache.set(key.virtualKey, key)
+        })
+    }
+
+    const resourceKeys = await loadJsonResource(`${resourcesBase}/input/virtual-keys.json`, VirtualKeysSchema)
+    mergeKeys(resourceKeys)
+
+    for (const p of paths) {
+        const keys = await loadJsonResource(`${basePath}/${p}/virtual-keys.json`, VirtualKeysSchema)
+        mergeKeys(keys)
+    }
+
+    return result
+}
+
+export async function loadVirtualInputs(paths: string[], virtualKeys: Record<string, VirtualKey>, basePath: string = BASE_PATH, resourcesBase: string = RESOURCE_PATH): Promise<Record<string, VirtualInput>> {
+    const result: Record<string, VirtualInput> = {}
+
+    const mergeInputs = (inputs: Array<{ virtualInput: string; virtualKeys: string[]; label: string }>) => {
+        inputs.forEach(i => {
+            const keys: VirtualKey[] = []
+            i.virtualKeys.forEach(k => {
+                const key = virtualKeys[k] || virtualKeyCache.get(k)
+                if (key) {
+                    keys.push(key)
+                }
+            })
+            result[i.virtualInput] = { virtualInput: i.virtualInput, virtualKeys: keys, label: i.label }
+        })
+    }
+
+    const resourceInputs = await loadJsonResource(`${resourcesBase}/input/virtual-inputs.json`, VirtualInputsSchema)
+    mergeInputs(resourceInputs)
+
+    for (const p of paths) {
+        let inputs
+        try {
+            inputs = await loadJsonResource(`${basePath}/${p}/virtual-inputs.json`, VirtualInputsSchema)
+        } catch {
+            inputs = await loadJsonResource(`${basePath}/${p}/virtual-input.json`, VirtualInputsSchema)
+        }
+        mergeInputs(inputs)
+    }
+
     return result
 }


### PR DESCRIPTION
## Summary
- extend game schema and data types to include input paths
- fetch virtual key definitions from resources and game data
- fetch virtual inputs after loading keys

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_687805fd1b908332911e9b326c6d9186