### PR TITLE
Fix Vite build import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can import modules using the configured aliases:
 - `@app/*` → `src/app/*`
 - `@loader/*` → `src/loader/*`
 - `@resources/*` → `src/resources/*`
+- `@engine/*` → `src/engine/*`
 
 ## Testing
 

--- a/src/app/game.tsx
+++ b/src/app/game.tsx
@@ -1,7 +1,7 @@
 import { logDebug } from '@utility/logMessage'
 import { useSyncExternalStore } from 'react'
-import { getGameEngine } from 'src/engine/gameEngine'
-import { GameEngineState } from 'src/engine/types'
+import { getGameEngine } from '@engine/gameEngine'
+import { GameEngineState } from '@engine/types'
 
 type GameProps = Record<string, never>
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { logDebug } from '@utility/logMessage'
 import { loadGameData } from '@loader/index'
 import type { GameData } from '@data/game/game'
 import App from '@app/game'
-import { GameEngine } from './engine/gameEngine'
+import { GameEngine } from '@engine/gameEngine'
 
 logDebug('Application starting...')
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -28,7 +28,8 @@
       "@data/*": ["src/data/*"],
       "@app/*": ["src/app/*"],
       "@loader/*": ["src/loader/*"],
-      "@resources/*": ["src/resources/*"]
+      "@resources/*": ["src/resources/*"],
+      "@engine/*": ["src/engine/*"]
     }
   },
   "include": ["src"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -27,7 +27,8 @@
       "@data/*": ["src/data/*"],
       "@app/*": ["src/app/*"],
       "@loader/*": ["src/loader/*"],
-      "@resources/*": ["src/resources/*"]
+      "@resources/*": ["src/resources/*"],
+      "@engine/*": ["src/engine/*"]
     }
   },
   "include": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig(({ mode }) => {
         '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
         '@loader': fileURLToPath(new URL('./src/loader', import.meta.url)),
         '@resources': fileURLToPath(new URL('./src/resources', import.meta.url)),
+        '@engine': fileURLToPath(new URL('./src/engine', import.meta.url)),
       },
     },
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       '@utility': fileURLToPath(new URL('./src/utility', import.meta.url)),
       '@data': fileURLToPath(new URL('./src/data', import.meta.url)),
       '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
+      '@engine': fileURLToPath(new URL('./src/engine', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- correct engine import paths in Game component
- add @engine alias to TypeScript config, Vite, and Vitest

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68791e181dcc833283c840c0e7eed5ef