### PR TITLE
Add screen control and grid layout

### DIFF
--- a/src/app/controls/screen.tsx
+++ b/src/app/controls/screen.tsx
@@ -1,0 +1,26 @@
+import type { Screen as GameScreen } from '@data/game/screen'
+import type { CSSProperties, ReactNode } from 'react'
+
+export type ScreenProps = {
+    screen: GameScreen
+    children?: ReactNode
+}
+
+const ScreenControl: React.FC<ScreenProps> = ({ screen, children }): React.JSX.Element => {
+    switch (screen.type) {
+        case 'grid': {
+            const style: CSSProperties = {
+                display: 'grid',
+                width: '100vw',
+                height: '100vh',
+                gridTemplateRows: `repeat(${screen.rows}, 1fr)`,
+                gridTemplateColumns: `repeat(${screen.columns}, 1fr)`
+            }
+            return <div style={style}>{children}</div>
+        }
+        default:
+            return <div>{children}</div>
+    }
+}
+
+export default ScreenControl

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import type { PageModule } from '@data/game/page'
+import ScreenControl from './controls/screen'
+import type { CSSProperties } from 'react'
 
 type PageProps = {
     module: PageModule
@@ -6,11 +8,20 @@ type PageProps = {
 
 const Page: React.FC<PageProps> = ({ module }): React.JSX.Element => {
     return (
-        <div>
-            <h1>Page</h1>
-            <p>{module.description}</p>
-            {/* Render other module-specific content here */}
-        </div>
+        <ScreenControl screen={module.screen}>
+            {module.components.map((c, idx) => {
+                const { row, column, rowSpan = 1, columnSpan = 1 } = c.position
+                const style: CSSProperties = {
+                    gridRow: `${row + 1} / span ${rowSpan}`,
+                    gridColumn: `${column + 1} / span ${columnSpan}`,
+                }
+                return (
+                    <div key={idx} style={style}>
+                        <div>{c.component.description}</div>
+                    </div>
+                )
+            })}
+        </ScreenControl>
     )
 }
 


### PR DESCRIPTION
## Summary
- add ScreenControl component to prepare a full-screen grid
- render page components within ScreenControl grid

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_687a5d8b1ce88332872870e8ba7ad9cd