### PR TITLE
Fix button action type requirement

### DIFF
--- a/src/data/game/component.ts
+++ b/src/data/game/component.ts
@@ -1,8 +1,10 @@
-export interface ButtonAction {
-    type?: string
+export interface PostMessageButtonAction {
+    type: 'post-message'
     message: string
     payload?: null | number | string | Record<string, unknown>
 }
+
+export type ButtonAction = PostMessageButtonAction
 
 export interface Button {
     label: string

--- a/src/data/load/component.ts
+++ b/src/data/load/component.ts
@@ -1,13 +1,15 @@
 import { z } from 'zod'
 
-export const buttonActionSchema = z.object({
-    type: z.string().optional(),
+const postMessageActionSchema = z.object({
+    type: z.literal('post-message'),
     message: z.string(),
     payload: z
         .union([z.number(), z.string(), z.record(z.string(), z.unknown())])
         .nullable()
         .optional(),
 })
+
+export const buttonActionSchema = z.discriminatedUnion('type', [postMessageActionSchema])
 
 export const buttonSchema = z.object({
     label: z.string(),


### PR DESCRIPTION
## Summary
- make `buttonActionSchema` discriminate on required type field
- tighten runtime/compile-time typings for button actions

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687a9c0393408332b17df74ef754b7e6