### PR TITLE
Add optional page background image support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,8 +9,13 @@ type PageProps = {
 }
 
 const Page: React.FC<PageProps> = ({ module }): React.JSX.Element => {
+    const pageStyle: CSSCustomProperties = {}
+    if (module.backgroundImage) {
+        pageStyle['--ge-page-background-image'] = `url("${module.backgroundImage}")`
+    }
     return (
-        <Screen screen={module.screen}>
+        <div className='game-page' style={pageStyle}>
+            <Screen screen={module.screen}>
             {module.components.map((c, idx) => {
                 const { row, column, rowSpan = 1, columnSpan = 1 } = c.position
                 const style: CSSCustomProperties = {
@@ -34,7 +39,8 @@ const Page: React.FC<PageProps> = ({ module }): React.JSX.Element => {
                     </div>
                 )
             })}
-        </Screen>
+            </Screen>
+        </div>
     )
 }
 

--- a/src/data/game/page.ts
+++ b/src/data/game/page.ts
@@ -18,4 +18,5 @@ export interface PageModule {
     description: string
     screen: Screen
     components: PageComponent[]
+    backgroundImage?: string
 }

--- a/src/data/load/page.ts
+++ b/src/data/load/page.ts
@@ -18,6 +18,7 @@ export const pageSchema = z.object({
     description: z.string(),
     screen: screenSchema,
     components: z.array(pageComponentSchema),
+    'background-image': z.string().optional(),
 })
 
 export type GridPosition = z.infer<typeof gridPositionSchema>

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -68,11 +68,14 @@ export async function loadModule(modulePath: string, basePath: string = BASE_PAT
             const comp = await loadComponentModule(c.type, basePath)
             components.push({ component: comp, position: { ...c.position } })
         }
+        const bg = load['background-image']
+        const moduleDir = `${basePath}/${modulePath}`
         result = {
             type: 'page',
             description: load.description,
             screen: { ...load.screen },
-            components
+            components,
+            backgroundImage: bg ? `${moduleDir}/${bg}` : undefined
         } as PageModule
     }
 

--- a/src/styling/index.css
+++ b/src/styling/index.css
@@ -9,6 +9,14 @@ body {
     font-family: var(--ge-font-family);
 }
 
+.game-page {
+    width: 100%;
+    height: 100%;
+    background-image: var(--ge-page-background-image);
+    background-size: cover;
+    background-position: center;
+}
+
 .screen-grid {
     display: grid;
     grid-template-rows: repeat(var(--ge-grid-rows), 1fr);

--- a/src/styling/variables.css
+++ b/src/styling/variables.css
@@ -16,4 +16,5 @@
     --ge-grid-item-position-column-start: 3;
     --ge-grid-item-position-row-end: 4;
     --ge-grid-item-position-column-end: 6;
+    --ge-page-background-image: none;
 }


### PR DESCRIPTION
## Summary
- extend page schema with optional `background-image`
- map background images in game data and loader
- expose CSS variable and style for page backgrounds
- render page backgrounds via css variable

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687b512fc4c4833285bf8b801ae48b39