### PR TITLE
Add tile loading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ lists all modules and supporting assets:
   "modules": ["pages/start", "components/game-menu"],
   "translations": ["translations"],
   "inputs": ["inputs"],
-  "css": ["css/game.css"]
+  "css": ["css/game.css"],
+  "tiles": ["tiles/outdoor", "tiles/now"]
 }
 ```
 
@@ -113,4 +114,15 @@ Translations are stored under a folder referenced from `game.json`. The
 Input mappings are defined in `virtual-keys.json` and `virtual-inputs.json`
 files. These map physical key codes to virtual keys and virtual keys to higher
 level virtual inputs used by the engine.
+
+Tile data is stored under folders listed in the `tiles` array. Each folder
+contains an `index.json` file with a list of tiles:
+
+```json
+{
+  "tiles": [
+    { "key": "outdoor.beach", "description": "OUTDOOR.TILE-BEACH", "color": "yellow" }
+  ]
+}
+```
 

--- a/sample-game/game.json
+++ b/sample-game/game.json
@@ -15,5 +15,9 @@
   ],
   "css": [
     "css/game.css"
+  ],
+  "tiles": [
+    "tiles/outdoor",
+    "tiles/now"
   ]
 }

--- a/sample-game/tiles/now/index.json
+++ b/sample-game/tiles/now/index.json
@@ -1,0 +1,14 @@
+{
+    "tiles": [
+        {
+            "key": "now.wall",
+            "description": "NOW.TILE-WALL",
+            "color": "gray"
+        },
+        {
+            "key": "now.floor",
+            "description": "NOW.TILE-FLOOR",
+            "color": "lightgray"
+        }
+    ]
+}

--- a/sample-game/translations/en/index.json
+++ b/sample-game/translations/en/index.json
@@ -9,6 +9,8 @@
         "OUTDOOR.TILE-DUNE": "Sand dunes.",
         "OUTDOOR.TILE-FOREST": "Forest. Large green trees.",
         "OUTDOOR.TILE-ROAD": "Cobblestones all the way.",
-        "OUTDOOR.TILE-GRASS": "Fields of green grass."
+        "OUTDOOR.TILE-GRASS": "Fields of green grass.",
+        "NOW.TILE-WALL": "Solid stone wall.",
+        "NOW.TILE-FLOOR": "Smooth stone floor."
     }
 }

--- a/src/data/game/game.ts
+++ b/src/data/game/game.ts
@@ -1,6 +1,7 @@
 import type { Module } from './module'
 import type { Translations } from './translation'
 import type { VirtualKey, VirtualInput } from './virtualInput'
+import type { Tile } from './tile'
 
 export interface GameData {
     title: string
@@ -12,4 +13,5 @@ export interface GameData {
     virtualKeys: Record<string, VirtualKey>
     virtualInputs: Record<string, VirtualInput>
     css: string[]
+    tiles: Record<string, Tile>
 }

--- a/src/data/game/tile.ts
+++ b/src/data/game/tile.ts
@@ -1,0 +1,6 @@
+export interface Tile {
+    key: string
+    description: string
+    color?: string
+    image?: string
+}

--- a/src/data/load/game.ts
+++ b/src/data/load/game.ts
@@ -9,6 +9,7 @@ export const gameSchema = z.object({
   translations: z.array(z.string()),
   inputs: z.array(z.string()).optional(),
   css: z.array(z.string()).optional(),
+  tiles: z.array(z.string()).optional(),
 })
 
 export type Game = z.infer<typeof gameSchema>

--- a/src/data/load/tile.ts
+++ b/src/data/load/tile.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const tileSchema = z.object({
+    key: z.string(),
+    description: z.string(),
+    color: z.string().optional(),
+    image: z.string().optional(),
+})
+
+export const tilesSchema = z.object({
+    tiles: z.array(tileSchema)
+})
+
+export type Tile = z.infer<typeof tileSchema>
+export type TileIndex = z.infer<typeof tilesSchema>

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -4,12 +4,14 @@ import { moduleSchema } from '@data/load/module'
 import { componentSchema } from '@data/load/component'
 import { translationsIndexSchema, languageDataSchema } from '@data/load/translation'
 import { VirtualKeysSchema, VirtualInputsSchema } from '@data/load/virtualInput'
+import { tilesSchema } from '@data/load/tile'
 import type { GameData } from '@data/game/game'
 import type { Module } from '@data/game/module'
 import type { ComponentModule } from '@data/game/component'
 import type { PageModule, PageComponent } from '@data/game/page'
 import type { Translations, LanguageData } from '@data/game/translation'
 import type { VirtualKey, VirtualInput } from '@data/game/virtualInput'
+import type { Tile } from '@data/game/tile'
 
 const BASE_PATH = '/data'
 const RESOURCE_PATH = '/resources'
@@ -17,6 +19,7 @@ const RESOURCE_PATH = '/resources'
 const moduleCache: Map<string, Module> = new Map()
 const translationCache: Map<string, LanguageData> = new Map()
 const virtualKeyCache: Map<string, VirtualKey> = new Map()
+const tileCache: Map<string, Record<string, Tile>> = new Map()
 
 export async function loadGameData(basePath: string = BASE_PATH): Promise<GameData> {
     const gameLoad = await loadJsonResource(`${basePath}/game.json`, gameSchema)
@@ -36,6 +39,12 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
     const virtualKeys = await loadVirtualKeys(inputPaths, basePath)
     const virtualInputs = await loadVirtualInputs(inputPaths, virtualKeys, basePath)
     const cssFiles = (gameLoad.css ?? []).map(p => `${basePath}/${p}`)
+    const tilePaths = gameLoad.tiles ?? []
+    const tiles: Record<string, Tile> = {}
+    for (const p of tilePaths) {
+        const set = await loadTiles(p, basePath)
+        Object.assign(tiles, set)
+    }
 
     return {
         title: gameLoad.title,
@@ -46,7 +55,8 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
         translations,
         virtualKeys,
         virtualInputs,
-        css: cssFiles
+        css: cssFiles,
+        tiles
     }
 }
 
@@ -183,5 +193,26 @@ export async function loadVirtualInputs(paths: string[], virtualKeys: Record<str
         mergeInputs(inputs)
     }
 
+    return result
+}
+
+export async function loadTiles(path: string, basePath: string = BASE_PATH): Promise<Record<string, Tile>> {
+    const cached = tileCache.get(path)
+    if (cached) {
+        return cached
+    }
+
+    const data = await loadJsonResource(`${basePath}/${path}/index.json`, tilesSchema)
+    const result: Record<string, Tile> = {}
+    for (const t of data.tiles) {
+        result[t.key] = {
+            key: t.key,
+            description: t.description,
+            color: t.color,
+            image: t.image ? `${basePath}/${path}/${t.image}` : undefined,
+        }
+    }
+
+    tileCache.set(path, result)
     return result
 }


### PR DESCRIPTION
## Summary
- support tiles in game.json
- add tile interface and load schemas
- load tile data in the loader
- document tiles in README
- add sample tile set `tiles/now`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bd21bef1883329e7420b68f1e3209