### PR TITLE
Add map loader

### DIFF
--- a/sample-game/game.json
+++ b/sample-game/game.json
@@ -19,5 +19,8 @@
   "tiles": [
     "tiles/outdoor",
     "tiles/now"
+  ],
+  "maps": [
+    "maps/start-beach"
   ]
 }

--- a/sample-game/translations/en/index.json
+++ b/sample-game/translations/en/index.json
@@ -11,6 +11,8 @@
         "OUTDOOR.TILE-ROAD": "Cobblestones all the way.",
         "OUTDOOR.TILE-GRASS": "Fields of green grass.",
         "NOW.TILE-WALL": "Solid stone wall.",
-        "NOW.TILE-FLOOR": "Smooth stone floor."
+        "NOW.TILE-FLOOR": "Smooth stone floor.",
+        "START-BEACH.NAME": "Start Beach",
+        "START-BEACH.DESCRIPTION": "A sunny beach where your journey begins."
     }
 }

--- a/src/data/game/game.ts
+++ b/src/data/game/game.ts
@@ -2,6 +2,7 @@ import type { Module } from './module'
 import type { Translations } from './translation'
 import type { VirtualKey, VirtualInput } from './virtualInput'
 import type { Tile } from './tile'
+import type { GameMap } from './map'
 
 export interface GameData {
     title: string
@@ -14,4 +15,5 @@ export interface GameData {
     virtualInputs: Record<string, VirtualInput>
     css: string[]
     tiles: Record<string, Tile>
+    maps: Record<string, GameMap>
 }

--- a/src/data/game/map.ts
+++ b/src/data/game/map.ts
@@ -1,0 +1,17 @@
+export interface MapTileDefinition {
+    key: string
+    tile: string
+}
+
+export interface SquaresMap {
+    type: 'squares-map'
+    key: string
+    name: string
+    description: string
+    width: number
+    height: number
+    tiles: Record<string, string>
+    map: string[][]
+}
+
+export type GameMap = SquaresMap

--- a/src/data/load/game.ts
+++ b/src/data/load/game.ts
@@ -10,6 +10,7 @@ export const gameSchema = z.object({
   inputs: z.array(z.string()).optional(),
   css: z.array(z.string()).optional(),
   tiles: z.array(z.string()).optional(),
+  maps: z.array(z.string()).optional(),
 })
 
 export type Game = z.infer<typeof gameSchema>

--- a/src/data/load/map.ts
+++ b/src/data/load/map.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const mapTileDefinitionSchema = z.object({
+    key: z.string(),
+    tile: z.string(),
+})
+
+export const squaresMapSchema = z.object({
+    key: z.string(),
+    name: z.string(),
+    description: z.string(),
+    type: z.literal('squares-map'),
+    width: z.number(),
+    height: z.number(),
+    tiles: z.array(mapTileDefinitionSchema),
+    map: z.array(z.string()),
+})
+
+export type MapTileDefinition = z.infer<typeof mapTileDefinitionSchema>
+export type SquaresMap = z.infer<typeof squaresMapSchema>

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -5,6 +5,7 @@ import { componentSchema } from '@data/load/component'
 import { translationsIndexSchema, languageDataSchema } from '@data/load/translation'
 import { VirtualKeysSchema, VirtualInputsSchema } from '@data/load/virtualInput'
 import { tilesSchema } from '@data/load/tile'
+import { squaresMapSchema } from '@data/load/map'
 import type { GameData } from '@data/game/game'
 import type { Module } from '@data/game/module'
 import type { ComponentModule } from '@data/game/component'
@@ -12,6 +13,7 @@ import type { PageModule, PageComponent } from '@data/game/page'
 import type { Translations, LanguageData } from '@data/game/translation'
 import type { VirtualKey, VirtualInput } from '@data/game/virtualInput'
 import type { Tile } from '@data/game/tile'
+import type { GameMap } from '@data/game/map'
 
 const BASE_PATH = '/data'
 const RESOURCE_PATH = '/resources'
@@ -20,6 +22,7 @@ const moduleCache: Map<string, Module> = new Map()
 const translationCache: Map<string, LanguageData> = new Map()
 const virtualKeyCache: Map<string, VirtualKey> = new Map()
 const tileCache: Map<string, Record<string, Tile>> = new Map()
+const mapCache: Map<string, GameMap> = new Map()
 
 export async function loadGameData(basePath: string = BASE_PATH): Promise<GameData> {
     const gameLoad = await loadJsonResource(`${basePath}/game.json`, gameSchema)
@@ -45,6 +48,12 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
         const set = await loadTiles(p, basePath)
         Object.assign(tiles, set)
     }
+    const mapPaths = gameLoad.maps ?? []
+    const maps: Record<string, GameMap> = {}
+    for (const p of mapPaths) {
+        const map = await loadMap(p, basePath)
+        maps[map.key] = map
+    }
 
     return {
         title: gameLoad.title,
@@ -56,7 +65,8 @@ export async function loadGameData(basePath: string = BASE_PATH): Promise<GameDa
         virtualKeys,
         virtualInputs,
         css: cssFiles,
-        tiles
+        tiles,
+        maps
     }
 }
 
@@ -214,5 +224,33 @@ export async function loadTiles(path: string, basePath: string = BASE_PATH): Pro
     }
 
     tileCache.set(path, result)
+    return result
+}
+
+export async function loadMap(path: string, basePath: string = BASE_PATH): Promise<GameMap> {
+    const cached = mapCache.get(path)
+    if (cached) {
+        return cached
+    }
+
+    const data = await loadJsonResource(`${basePath}/${path}/index.json`, squaresMapSchema)
+    const tiles: Record<string, string> = {}
+    data.tiles.forEach(t => {
+        tiles[t.key] = t.tile
+    })
+    const mapRows = data.map.map(row => row.split(','))
+
+    const result: GameMap = {
+        type: 'squares-map',
+        key: data.key,
+        name: data.name,
+        description: data.description,
+        width: data.width,
+        height: data.height,
+        tiles,
+        map: mapRows,
+    }
+
+    mapCache.set(path, result)
     return result
 }


### PR DESCRIPTION
## Summary
- add `Map` interface and map load schema
- support `maps` field when loading game data
- create helper to load maps from JSON files
- enable `maps/start-beach` in sample game
- provide translations for map name & description

## Testing
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687be319c8e883329a151771c965df0a