### PR TITLE
Add navigate page to sample-game modules

### DIFF
--- a/sample-game/game.json
+++ b/sample-game/game.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "modules": [
     "pages/start",
+    "pages/navigate",
     "components/game-menu"
   ],
   "translations": [


### PR DESCRIPTION
## Summary
- include `pages/navigate` in the sample game's `modules` list

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bea44b4a483328ca1e6873ebceb05