### PR TITLE
Add missing module check

### DIFF
--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -100,7 +100,10 @@ export class GameEngine implements IGameEngine {
     updatePage(page: string): void {
         this._state.value = GameEngineState.loading
         logInfo('Switching to page: {0}', page)
-        const module = this.game.modules[page] 
+        const module = this.game.modules[page]
+        if (!module) {
+            fatalError(`Page module ${page} not found`)
+        }
         if (module.type !== 'page') {
             fatalError(`Module ${page} is not a page module`)
         }

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { GameEngine } from '@engine/gameEngine'
+import type { GameData } from '@data/game/game'
+
+vi.mock('@utility/logMessage', async () => {
+  const actual = await vi.importActual<typeof import('@utility/logMessage')>('@utility/logMessage')
+  return {
+    ...actual,
+    logInfo: vi.fn(),
+    logDebug: vi.fn(),
+    logWarning: vi.fn(),
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('GameEngine', () => {
+  it('throws when updating to an unknown page', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const game: GameData = {
+      title: 't',
+      description: '',
+      version: '1',
+      startPage: 'start',
+      modules: {
+        start: {
+          type: 'page',
+          description: '',
+          screen: { type: 'grid', rows: 1, columns: 1 },
+          components: [],
+        },
+      },
+      translations: { languages: {} },
+      virtualKeys: {},
+      virtualInputs: {},
+      css: [],
+      tiles: {},
+      maps: {},
+    }
+
+    const engine = new GameEngine(game)
+    expect(() => engine.updatePage('missing')).toThrowError('Page module missing not found')
+    engine.cleanup()
+    errorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- validate page module exists before checking type
- add GameEngine unit test for missing module

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687bea4c33108332a16a3abab71e69e1