### PR TITLE
Add utils folder alias

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,9 @@
+import { useEffect } from 'react'
+import { logInfo } from '@utils/logMessage'
+
 export default function App() {
+  useEffect(() => {
+    logInfo('App mounted')
+  }, [])
   return <div>Game engine initialized.</div>
 }

--- a/test/utils/array.test.ts
+++ b/test/utils/array.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { create2DArray } from '../../src/utils/array'
+import { create2DArray } from '@utils/array'
 
 describe('create2DArray', () => {
   it('creates a 2D array with specified dimensions and initial value', () => {

--- a/test/utils/map.test.ts
+++ b/test/utils/map.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { hasMapChanged, updateMap } from '../../src/utils/map'
+import { hasMapChanged, updateMap } from '@utils/map'
 
 describe('hasMapChanged', () => {
   it('returns false for identical maps', () => {

--- a/test/utils/objectPath.test.ts
+++ b/test/utils/objectPath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { setValueAtPath } from '../../src/utils/objectPath'
+import { setValueAtPath } from '@utils/objectPath'
 
 describe('setValueAtPath', () => {
   it('sets value on existing path', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["src/utils/*"]
+    }
   },
   "include": ["src", "test"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@utils': fileURLToPath(new URL('./src/utils', import.meta.url)),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- alias `@utils` to `src/utils`
- update tests and App example to use alias

## Testing
- `npm run build`
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6884f902a0c48332b1050bb84a7224df