### PR TITLE
Add tests for new utils and update README

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MPL-2.0",
       "devDependencies": {
+        "@eslint/js": "^9.32.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@typescript-eslint/eslint-plugin": "^8.38.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:fix": "eslint . --ext .ts,.tsx --fix"
   },
   "devDependencies": {
+    "@eslint/js": "^9.32.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@typescript-eslint/eslint-plugin": "^8.38.0",

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -9,3 +9,7 @@ A small collection of helper functions used across the engine.
 - **hasMapChanged**: Compares two maps using a custom equality check and reports if they differ.
 - **updateMap**: Replaces the contents of one map with cloned entries from another.
 - **setValueAtPath**: Sets a value on an object given a dot separated path.
+- **loadJsonResource**: Fetches a JSON resource from a URL and validates it using a Zod schema.
+- **MessageBus**: Lightweight publish/subscribe queue that delivers posted messages to registered listeners.
+- **TrackedValue**: Observable wrapper for a value that notifies subscribers when it changes.
+- **CleanUp / Message**: Helper types used by other utilities.

--- a/test/utils/loadJsonResource.test.ts
+++ b/test/utils/loadJsonResource.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { z } from 'zod'
+import { loadJsonResource } from '@utils/loadJsonResource'
+
+describe('loadJsonResource', () => {
+  const url = 'http://example.com/data.json'
+  const schema = z.object({ a: z.number() })
+  let originalFetch: typeof fetch
+
+  beforeEach(() => {
+    // @ts-ignore
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    // @ts-ignore
+    globalThis.fetch = originalFetch
+  })
+
+  it('loads and validates json', async () => {
+    const json = { a: 5 }
+    const response = { ok: true, json: vi.fn().mockResolvedValue(json) } as unknown as Response
+    const fetchMock = vi.fn().mockResolvedValue(response)
+    // @ts-ignore
+    globalThis.fetch = fetchMock as any
+
+    const result = await loadJsonResource(url, schema)
+    expect(result).toEqual(json)
+    expect(fetchMock).toHaveBeenCalledWith(url)
+  })
+
+  it('throws when validation fails', async () => {
+    const response = { ok: true, json: vi.fn().mockResolvedValue({ a: 'x' }) } as unknown as Response
+    // @ts-ignore
+    globalThis.fetch = vi.fn().mockResolvedValue(response) as any
+
+    await expect(loadJsonResource(url, schema)).rejects.toThrow()
+  })
+})

--- a/test/utils/messageBus.test.ts
+++ b/test/utils/messageBus.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MessageBus } from '@utils/messageBus'
+
+describe('MessageBus', () => {
+  it('delivers messages to listeners and empties the queue', () => {
+    const onEmpty = vi.fn()
+    const bus = new MessageBus(onEmpty)
+    const handler = vi.fn()
+    bus.registerMessageListener('hello', handler)
+
+    bus.postMessage({ message: 'hello', payload: 42 })
+
+    expect(handler).toHaveBeenCalledWith({ message: 'hello', payload: 42 })
+    expect(onEmpty).toHaveBeenCalled()
+  })
+
+  it('processes queued messages after re-enabling automatic emptying', () => {
+    const onEmpty = vi.fn()
+    const bus = new MessageBus(onEmpty)
+    const handler = vi.fn()
+    bus.registerMessageListener('test', handler)
+
+    bus.disableEmptyQueueAfterPost()
+    bus.postMessage({ message: 'test', payload: null })
+    expect(handler).not.toHaveBeenCalled()
+    expect(onEmpty).not.toHaveBeenCalled()
+
+    bus.enableEmptyQueueAfterPost()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(onEmpty).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/utils/trackedState.test.ts
+++ b/test/utils/trackedState.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { TrackedValue } from '@utils/trackedState'
+
+describe('TrackedValue', () => {
+  it('notifies subscribers and callback on value change', () => {
+    const callback = vi.fn()
+    const tracked = new TrackedValue<number>('num', 0, callback)
+    const subscriber = vi.fn()
+    const unsubscribe = tracked.subscribe(subscriber)
+
+    tracked.value = 1
+    expect(subscriber).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith(1, 0)
+
+    subscriber.mockClear()
+    callback.mockClear()
+    unsubscribe()
+
+    tracked.value = 2
+    expect(subscriber).not.toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(2, 1)
+  })
+})


### PR DESCRIPTION
## Summary
- document newly added utilities
- add unit tests for `MessageBus`, `TrackedValue` and `loadJsonResource`
- include `@eslint/js` so linting works

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688504ba9ef4833283b0ea0c02f302c0