### PR TITLE
Copy game folder on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ for a development server, or build with:
 npm run build
 ```
 
+The build step copies the game data from the directory specified by the
+`GAME_FOLDER` environment variable into `dist/data`. If this variable is not
+set, the `sample-game` folder is used.
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,15 @@ import react from '@vitejs/plugin-react'
 import copy from 'rollup-plugin-copy'
 import { fileURLToPath, URL } from 'node:url'
 
+const gameFolder = process.env.GAME_FOLDER || 'sample-game'
+
 export default defineConfig({
   plugins: [
     react(),
     copy({
       targets: [
         { src: 'resources', dest: 'dist', rename: 'res' },
+        { src: gameFolder, dest: 'dist', rename: 'data' },
       ],
       hook: 'writeBundle',
       verbose: true,


### PR DESCRIPTION
## Summary
- copy game data folder to `dist/data`
- make game folder path configurable via the `GAME_FOLDER` environment variable
- document game data copy step

## Testing
- `npm run lint`
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885212d70e88332a08606e37fdf0ed4