### PR TITLE
Add engine tests

### DIFF
--- a/test/engine/changeTracker.test.ts
+++ b/test/engine/changeTracker.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { ChangeTracker } from '../../src/engine/changeTracker'
+
+interface Data extends Record<string, unknown> { value: number }
+
+describe('ChangeTracker', () => {
+  it('undo reverts changes for each turn', () => {
+    const tracker = new ChangeTracker<Data>()
+    const data: Data = { value: 0 }
+
+    tracker.trackChange({ path: 'value', oldValue: 0, newValue: 1 })
+    data.value = 1
+    tracker.startNewTurn()
+    tracker.trackChange({ path: 'value', oldValue: 1, newValue: 2 })
+    data.value = 2
+
+    tracker.undo(data)
+    expect(data.value).toBe(1)
+    tracker.undo(data)
+    expect(data.value).toBe(0)
+  })
+
+  it('save and load restore state with consolidated turns', () => {
+    const tracker = new ChangeTracker<Data>(2)
+    const data: Data = { value: 0 }
+
+    tracker.trackChange({ path: 'value', oldValue: 0, newValue: 1 })
+    data.value = 1
+    tracker.startNewTurn()
+
+    tracker.trackChange({ path: 'value', oldValue: 1, newValue: 2 })
+    data.value = 2
+    tracker.startNewTurn()
+
+    tracker.trackChange({ path: 'value', oldValue: 2, newValue: 3 })
+    data.value = 3
+
+    const save = tracker.save()
+
+    const tracker2 = new ChangeTracker<Data>()
+    const data2: Data = { value: 0 }
+    tracker2.load(data2, save)
+    expect(data2.value).toBe(3)
+  })
+})

--- a/test/engine/stateManager.test.ts
+++ b/test/engine/stateManager.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { ChangeTracker } from '../../src/engine/changeTracker'
+import { StateManager } from '../../src/engine/stateManager'
+
+interface Data extends Record<string, unknown> { count: number }
+
+describe('StateManager', () => {
+  it('rolls back changes turn by turn', () => {
+    const tracker = new ChangeTracker<Data>()
+    const manager = new StateManager<Data>({ count: 0 }, tracker)
+
+    manager.state.count = 1
+    manager.commitTurn()
+    manager.state.count = 2
+
+    manager.rollbackTurn()
+    expect(manager.state.count).toBe(1)
+    manager.rollbackTurn()
+    expect(manager.state.count).toBe(0)
+  })
+
+  it('saves and loads state', () => {
+    const tracker = new ChangeTracker<Data>()
+    const manager = new StateManager<Data>({ count: 0 }, tracker)
+
+    manager.state.count = 1
+    manager.commitTurn()
+    manager.state.count = 2
+    const save = manager.save()
+
+    const tracker2 = new ChangeTracker<Data>()
+    const manager2 = new StateManager<Data>({ count: 0 }, tracker2)
+    manager2.load(save)
+    expect(manager2.state.count).toBe(2)
+    manager2.rollbackTurn()
+    expect(manager2.state.count).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for new state manager and change tracker

## Testing
- `npm run build`
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6885d936866c833281a689ddf7afb62f