### PR TITLE
Add basic JSON editor entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ The project uses [Vite](https://vitejs.dev/) with **React** and TypeScript. Afte
 npm run dev
 ```
 
-for a development server, or build with:
+for a development server, or start the JSON editor with:
+
+```bash
+npm run dev:editor
+```
+
+Build with:
 
 ```bash
 npm run build

--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Game Editor</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/editor/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:editor": "vite --open /editor.html",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/editor/main.tsx
+++ b/src/editor/main.tsx
@@ -1,0 +1,22 @@
+import { createRoot } from 'react-dom/client'
+import { useState } from 'react'
+import '../style.css'
+
+function EditorApp() {
+  const [json, setJson] = useState('{}')
+  return (
+    <div>
+      <h1>Game JSON Editor</h1>
+      <textarea
+        style={{ width: '100%', height: '80vh' }}
+        value={json}
+        onChange={(e) => setJson(e.target.value)}
+      />
+    </div>
+  )
+}
+
+const root = document.getElementById('app')
+if (root) {
+  createRoot(root).render(<EditorApp />)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 import { fileURLToPath, URL } from 'node:url'
+import { resolve } from 'node:path'
 
 const gameFolder = process.env.GAME_FOLDER || 'sample-game'
+const rootDir = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig({
   plugins: [
@@ -21,6 +23,14 @@ export default defineConfig({
   resolve: {
     alias: {
       '@utils': fileURLToPath(new URL('./src/utils', import.meta.url)),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(rootDir, 'index.html'),
+        editor: resolve(rootDir, 'editor.html'),
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- add `src/editor/main.tsx` and `editor.html`
- configure Vite for multi-page input
- add `dev:editor` script
- document editor usage in README

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887b347b518833299d924754d9f2fe3