### PR TITLE
Fix dev port collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ The project uses [Vite](https://vitejs.dev/) with **React** and TypeScript. Afte
 npm run dev
 ```
 
-for a development server, or start the JSON editor with:
+for a development server on port `5173`, or start the JSON editor with:
 
 ```bash
 npm run dev:editor
 ```
+
+This command serves the editor on port `5174`.
 
 Build with:
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "dev:editor": "vite --open /editor.html",
+    "dev": "vite --port 5173",
+    "dev:editor": "vite --port 5174 --open /editor.html",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- set explicit ports for dev scripts
- document port usage in README

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6887b688af0483328a65d222db9658e4