### PR TITLE
Add editor-less build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Build with:
 npm run build
 ```
 
+To build without including the editor, run:
+
+```bash
+npm run build:release
+```
+
 The build step copies the game data from the directory specified by the
 `GAME_FOLDER` environment variable into `dist/data`. If this variable is not
 set, the `sample-game` folder is used.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "vite --port 5173",
     "dev:editor": "vite --port 5174 --open /editor.html",
     "build": "tsc && vite build",
+    "build:release": "WITH_EDITOR=false npm run build",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint . --ext .ts,.tsx",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { resolve } from 'node:path'
 
 const gameFolder = process.env.GAME_FOLDER || 'sample-game'
 const rootDir = fileURLToPath(new URL('.', import.meta.url))
+const withEditor = process.env.WITH_EDITOR !== 'false'
 
 export default defineConfig({
   plugins: [
@@ -29,7 +30,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         index: resolve(rootDir, 'index.html'),
-        editor: resolve(rootDir, 'editor.html'),
+        ...(withEditor ? { editor: resolve(rootDir, 'editor.html') } : {}),
       },
     },
   },


### PR DESCRIPTION
## Summary
- make Vite config optionally include the editor based on `WITH_EDITOR`
- add a `build:release` script
- document how to build without the editor

## Testing
- `npm run build`
- `npm run build:release`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6887e58f68648332a5a79d927b7e18de