### PR TITLE
Add TS/Vite path aliases

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
-import { GameEngineState, getGameEngine } from '../engine/gameEngine'
-import { PAGE_SWITCHED_MESSAGE } from '../engine/messages'
-import type { Page as PageData } from '../loader/data/page'
+import { GameEngineState, getGameEngine } from '@engine/gameEngine'
+import { PAGE_SWITCHED_MESSAGE } from '@engine/messages'
+import type { Page as PageData } from '@loader/data/page'
 import { Page } from './page'
 
 export const App: React.FC = (): React.JSX.Element => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import type { Page as PageData } from 'src/loader/data/page'
+import type { Page as PageData } from '@loader/data/page'
 
 type PageProps = {
     page: PageData | null

--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -1,13 +1,13 @@
 import { fatalError, logDebug } from '@utils/logMessage'
 import { MessageBus, type IMessageBus } from '@utils/messageBus'
-import type { ILoader } from 'src/loader/loader'
+import type { ILoader } from '@loader/loader'
 import { END_TURN_MESSAGE, ENGINE_STATE_CHANGED_MESSAGE, SWITCH_PAGE_MESSAGE } from './messages'
 import { StateManager, type IStateManager } from './stateManager'
 import { ChangeTracker } from './changeTracker'
 import { TrackedValue, type ITrackedValue } from '@utils/trackedState'
 import { TranslationService, type ITranslationService } from './translationService'
 import { PageManager, type IPageManager } from './pageManager'
-import type { Page } from 'src/loader/data/page'
+import type { Page } from '@loader/data/page'
 
 let gameEngine: GameEngine | null = null
 function setGameEngine(engine: GameEngine): void {

--- a/src/engine/translationService.ts
+++ b/src/engine/translationService.ts
@@ -1,5 +1,5 @@
 import { fatalError } from '@utils/logMessage'
-import type { Language } from 'src/loader/data/language'
+import type { Language } from '@loader/data/language'
 
 export interface ITranslationService {
     translate(key: string): string

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
 import { createRoot } from 'react-dom/client'
 import './style.css'
 import { logDebug } from '@utils/logMessage'
-import { Loader, type ILoader } from './loader/loader'
-import { GameEngine, type IGameEngine } from './engine/gameEngine'
-import { App } from './app/app'
+import { Loader, type ILoader } from '@loader/loader'
+import { GameEngine, type IGameEngine } from '@engine/gameEngine'
+import { App } from '@app/app'
 
 logDebug('Application starting ...')
 

--- a/test/engine/changeTracker.test.ts
+++ b/test/engine/changeTracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ChangeTracker } from '../../src/engine/changeTracker'
+import { ChangeTracker } from '@engine/changeTracker'
 
 interface Data extends Record<string, unknown> { value: number }
 

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
-import { PageManager } from '../../src/engine/pageManager'
-import { ChangeTracker } from '../../src/engine/changeTracker'
-import { StateManager } from '../../src/engine/stateManager'
+import { PageManager } from '@engine/pageManager'
+import { ChangeTracker } from '@engine/changeTracker'
+import { StateManager } from '@engine/stateManager'
 import { TrackedValue } from '@utils/trackedState'
-import { GameEngineState, type ContextData, type IGameEngine } from '../../src/engine/gameEngine'
-import type { IPageManager } from '../../src/engine/pageManager'
+import { GameEngineState, type ContextData, type IGameEngine } from '@engine/gameEngine'
+import type { IPageManager } from '@engine/pageManager'
 
 function createTestEngine() {
   const loader = {

--- a/test/engine/stateManager.test.ts
+++ b/test/engine/stateManager.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { ChangeTracker } from '../../src/engine/changeTracker'
-import { StateManager } from '../../src/engine/stateManager'
+import { ChangeTracker } from '@engine/changeTracker'
+import { StateManager } from '@engine/stateManager'
 
 interface Data extends Record<string, unknown> { count: number }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,9 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
+      "@app/*": ["src/app/*"],
+      "@engine/*": ["src/engine/*"],
+      "@loader/*": ["src/loader/*"],
       "@utils/*": ["src/utils/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      '@app': fileURLToPath(new URL('./src/app', import.meta.url)),
+      '@engine': fileURLToPath(new URL('./src/engine', import.meta.url)),
+      '@loader': fileURLToPath(new URL('./src/loader', import.meta.url)),
       '@utils': fileURLToPath(new URL('./src/utils', import.meta.url)),
     },
   },


### PR DESCRIPTION
## Summary
- add aliases for app, engine, and loader folders
- update imports to use the new aliases

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6888a5fe692c8332acd27fd5839cbd74