### PR TITLE
Fix typos in loader error strings

### DIFF
--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -66,7 +66,7 @@ export class Loader implements ILoader {
 
     public async loadPage(page: string): Promise<PageData> {
         if (this.pages.has(page)) return this.pages.get(page)!
-        const path = this.game?.pages[page] ?? fatalError('Unknow page: {0}', page)
+        const path = this.game?.pages[page] ?? fatalError('Unknown page: {0}', page)
         return pageLoader(`${this.basePath}/${path}`, result => this.pages.set(page, result))
     }
 

--- a/src/loader/pageLoader.ts
+++ b/src/loader/pageLoader.ts
@@ -42,6 +42,6 @@ function getComponent(component: Component): ComponentData {
                 }
             }
         default:
-            fatalError('Unsupport page component type: {0}', component.type)
+            fatalError('Unsupported page component type: {0}', component.type)
     }
 }


### PR DESCRIPTION
## Summary
- fix typo 'Unknow page' => 'Unknown page'
- fix typo 'Unsupport page component type' => 'Unsupported page component type'

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68892de1a7c88332b78e1794919d1012