### PR TITLE
Implement grid positioning via CSS variables

### DIFF
--- a/src/app/controls/screen.tsx
+++ b/src/app/controls/screen.tsx
@@ -17,9 +17,14 @@ export const Screen: React.FC<ScreenProps> = ({ screen, components }): React.JSX
                 <div style={style} className='screen-grid'>
                     {components.map((component, index) => {
                         const key = `${component.type}_${index}`
-                        // TODO: set css variables to position the grid component
+                        const componentStyle: CSSCustomProperties = {
+                            '--grid-top': component.position.top.toString(),
+                            '--grid-left': component.position.left.toString(),
+                            '--grid-right': component.position.right.toString(),
+                            '--grid-bottom': component.position.bottom.toString(),
+                        }
                         return (
-                            <div className='grid-component' key={key}>
+                            <div className='grid-component' style={componentStyle} key={key}>
                                 TODO: render component here
                             </div>
                         )

--- a/src/style/game.css
+++ b/src/style/game.css
@@ -16,3 +16,10 @@ body {
     width: 100vw;
     height: 100vh;
 }
+
+.grid-component {
+    grid-column-start: var(--grid-left);
+    grid-column-end: var(--grid-right);
+    grid-row-start: var(--grid-top);
+    grid-row-end: var(--grid-bottom);
+}

--- a/test/app/screen.test.tsx
+++ b/test/app/screen.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { Screen } from '@app/controls/screen'
+import type { Component, Screen as ScreenData } from '@loader/data/page'
+
+describe('Screen', () => {
+  it('applies grid position variables to components', () => {
+    const screenData: ScreenData = { type: 'grid', width: 10, height: 10 }
+    const components: Component[] = [
+      { type: 'game-menu', position: { top: 1, left: 2, right: 3, bottom: 4 } },
+    ]
+
+    const element = Screen({ screen: screenData, components }) as React.ReactElement<Record<string, unknown>>
+    const child = (element.props.children as React.ReactElement<Record<string, unknown>>[])[0]
+    const style = child.props.style as Record<string, string>
+
+    expect(style['--grid-top']).toBe('1')
+    expect(style['--grid-left']).toBe('2')
+    expect(style['--grid-right']).toBe('3')
+    expect(style['--grid-bottom']).toBe('4')
+  })
+})


### PR DESCRIPTION
## Summary
- compute CSS variables for grid component placement in `Screen`
- use those variables in styles so grid items position correctly
- test that component positioning variables are set

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68892df814548332910d61bb1fec43b2