### PR TITLE
Improve editor save validation and add tests

### DIFF
--- a/src/editor/main.tsx
+++ b/src/editor/main.tsx
@@ -2,6 +2,30 @@ import { createRoot } from 'react-dom/client'
 import { useState, useEffect } from 'react'
 import './editor.css'
 
+export async function saveGame(
+  json: string,
+  fetchFn: typeof fetch = fetch,
+  alertFn: (msg: string) => void = alert,
+) {
+  try {
+    JSON.parse(json)
+  } catch {
+    alertFn('Invalid JSON')
+    return
+  }
+  const response = await fetchFn('/api/game', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: json,
+  })
+  if (response.ok) {
+    alertFn('Saved')
+  } else {
+    const error = await response.text()
+    alertFn(error)
+  }
+}
+
 function EditorApp() {
   const [json, setJson] = useState('{}')
 
@@ -12,14 +36,7 @@ function EditorApp() {
       .catch(() => setJson('{}'))
   }, [])
 
-  const save = async () => {
-    await fetch('/api/game', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: json,
-    })
-    alert('Saved')
-  }
+  const save = () => saveGame(json)
   return (
     <div>
       <h1>Game JSON Editor</h1>
@@ -33,7 +50,9 @@ function EditorApp() {
   )
 }
 
-const root = document.getElementById('app')
-if (root) {
-  createRoot(root).render(<EditorApp />)
+if (typeof document !== 'undefined') {
+  const root = document.getElementById('app')
+  if (root) {
+    createRoot(root).render(<EditorApp />)
+  }
 }

--- a/test/editor/saveGame.test.ts
+++ b/test/editor/saveGame.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { saveGame } from '../../src/editor/main'
+
+describe('saveGame', () => {
+  it('alerts when json is invalid and does not fetch', async () => {
+    const fetchMock = vi.fn()
+    const alertMock = vi.fn()
+    await saveGame('invalid', fetchMock as any, alertMock)
+    expect(alertMock).toHaveBeenCalledWith('Invalid JSON')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('posts json and alerts on success', async () => {
+    const response = { ok: true } as Response
+    const fetchMock = vi.fn().mockResolvedValue(response)
+    const alertMock = vi.fn()
+    await saveGame('{}', fetchMock as any, alertMock)
+    expect(fetchMock).toHaveBeenCalledWith('/api/game', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+    expect(alertMock).toHaveBeenCalledWith('Saved')
+  })
+
+  it('alerts error text when request fails', async () => {
+    const response = { ok: false, text: vi.fn().mockResolvedValue('error') } as unknown as Response
+    const fetchMock = vi.fn().mockResolvedValue(response)
+    const alertMock = vi.fn()
+    await saveGame('{}', fetchMock as any, alertMock)
+    expect(alertMock).toHaveBeenCalledWith('error')
+  })
+})


### PR DESCRIPTION
## Summary
- validate JSON before saving in editor
- notify user on invalid input or server errors
- export a `saveGame` helper and use in editor
- guard DOM mounting for test environment
- test `saveGame` behavior

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6889f07f14888332bffe9505453f6c5d