### PR TITLE
Implement action execution

### DIFF
--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -101,7 +101,16 @@ export class GameEngine implements IGameEngine {
     }
 
     public executeAction(action: Action): void {
-        logDebug('TODO action: {0}', action)
+        switch (action.type) {
+            case 'post-message':
+                this.messageBus.postMessage({
+                    message: action.message,
+                    payload: action.payload
+                })
+                break
+            default:
+                fatalError('Unsupported action type')
+        }
     }
 
     public get StateManager(): IStateManager<ContextData> {

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GameEngine } from '@engine/gameEngine'
+import type { ILoader } from '@loader/loader'
+import type { Action } from '@loader/data/action'
+
+function createEngine() {
+  const loader = {} as unknown as ILoader
+  const engine = new GameEngine(loader)
+  const bus = {
+    postMessage: vi.fn(),
+    registerMessageListener: vi.fn(),
+    registerNotificationMessage: vi.fn(),
+    shutDown: vi.fn()
+  } as any
+  ;(engine as any).messageBus = bus
+  return { engine, bus }
+}
+
+describe('GameEngine.executeAction', () => {
+  it('posts messages for post-message actions', () => {
+    const { engine, bus } = createEngine()
+    const action: Action = { type: 'post-message', message: 'TEST.MSG', payload: { a: 1 } }
+
+    engine.executeAction(action)
+
+    expect(bus.postMessage).toHaveBeenCalledWith({
+      message: 'TEST.MSG',
+      payload: { a: 1 }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- implement action interpretation in `GameEngine`
- verify `executeAction` posts the correct message

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688a6981a16c833286befe46ba058d70