### PR TITLE
Handle fetch failures in editor saveGame

### DIFF
--- a/src/editor/main.tsx
+++ b/src/editor/main.tsx
@@ -13,11 +13,17 @@ export async function saveGame(
     alertFn('Invalid JSON')
     return
   }
-  const response = await fetchFn('/api/game', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: json,
-  })
+  let response: Response
+  try {
+    response = await fetchFn('/api/game', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: json,
+    })
+  } catch (e) {
+    alertFn((e as Error).message)
+    return
+  }
   if (response.ok) {
     alertFn('Saved')
   } else {

--- a/test/editor/saveGame.test.ts
+++ b/test/editor/saveGame.test.ts
@@ -30,4 +30,11 @@ describe('saveGame', () => {
     await saveGame('{}', fetchMock as any, alertMock)
     expect(alertMock).toHaveBeenCalledWith('error')
   })
+
+  it('alerts error message when fetch rejects', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network'))
+    const alertMock = vi.fn()
+    await saveGame('{}', fetchMock as any, alertMock)
+    expect(alertMock).toHaveBeenCalledWith('network')
+  })
 })


### PR DESCRIPTION
## Summary
- handle rejected fetches in `saveGame`
- alert the message from fetch errors
- test fetch rejection handling

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_688a698996448332a5bb5104b5d5c0fd