### PR TITLE
Remove stray debug line

### DIFF
--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -1,4 +1,4 @@
-import { fatalError, logDebug } from '@utils/logMessage'
+import { fatalError } from '@utils/logMessage'
 import { MessageBus, type IMessageBus } from '@utils/messageBus'
 import type { ILoader } from '@loader/loader'
 import { END_TURN_MESSAGE, ENGINE_STATE_CHANGED_MESSAGE, SWITCH_PAGE_MESSAGE } from './messages'
@@ -159,7 +159,6 @@ export class GameEngine implements IGameEngine {
 
     private endTurn(): void {
         this.stateManager?.commitTurn()
-        logDebug('TEST: {0}', this.stateManager?.save())
     }
 
     private initStateManager(): void {


### PR DESCRIPTION
## Summary
- remove unused `logDebug` import
- drop the debug log line in `endTurn`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688aa17b772c833288c97b13c919a39e