### PR TITLE
Fix objectPath path validation

### DIFF
--- a/src/utils/objectPath.ts
+++ b/src/utils/objectPath.ts
@@ -1,12 +1,23 @@
-export function setValueAtPath(obj: Record<string, unknown>, path: string, value: unknown): void {
+export function setValueAtPath(
+    obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
+): void {
     const parts = path.split('.');
     let current: Record<string, unknown> = obj;
+
     for (let i = 0; i < parts.length - 1; i++) {
         const next = current[parts[i]];
         if (typeof next === 'object' && next !== null) {
             current = next as Record<string, unknown>;
+        } else {
+            // Abort if an intermediate segment does not exist
+            return;
         }
     }
+
     const last = parts[parts.length - 1];
-    current[last] = value;
+    if (Object.prototype.hasOwnProperty.call(current, last)) {
+        current[last] = value;
+    }
 }

--- a/test/utils/objectPath.test.ts
+++ b/test/utils/objectPath.test.ts
@@ -12,5 +12,6 @@ describe('setValueAtPath', () => {
     const obj: Record<string, any> = {}
     setValueAtPath(obj, 'x.y', 3)
     expect(obj.x).toBeUndefined()
+    expect(Object.keys(obj).length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- ensure `setValueAtPath` only writes to existing paths
- check no new keys are added on incomplete paths

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aa18d16f4833283ea4d433c31a7a8