### PR TITLE
Implement registerGameHandlers method

### DIFF
--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -184,6 +184,16 @@ export class GameEngine implements IGameEngine {
 
     private async registerGameHandlers(): Promise<void> {
         this.cleanupHandlers()
-        // TODO: load all handlers files, register each handler, keep track of cleanup
+        const handlerFiles = this.loader.Game.handlers
+        for (const path of handlerFiles) {
+            const handlers = await this.loader.loadHandlers(path)
+            handlers.forEach(handler => {
+                const cleanup = this.messageBus.registerMessageListener(
+                    handler.message,
+                    () => this.executeAction(handler.action)
+                )
+                this.handlerCleanupList.push(cleanup)
+            })
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement logic in `registerGameHandlers`
- load handler files from loader and register them with the message bus

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688aa4ff283c8332ba8b1ad600839a78