### PR TITLE
Add on-demand tile set loading

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -22,6 +22,7 @@ export const GameEditor: React.FC = () => {
           },
           languages: { ...parsed.languages },
           pages: { ...parsed.pages },
+          tiles: { ...parsed.tiles },
           handlers: [...parsed.handlers],
         }
         setGame(result)
@@ -35,6 +36,7 @@ export const GameEditor: React.FC = () => {
           initialData: { language: '', startPage: '' },
           languages: {},
           pages: {},
+          tiles: {},
           handlers: [],
         })
         setStyling([])
@@ -89,6 +91,7 @@ export const GameEditor: React.FC = () => {
       },
       languages: game.languages,
       pages: game.pages,
+      tiles: game.tiles,
       styling,
       handlers: game.handlers,
     }

--- a/src/loader/data/game.ts
+++ b/src/loader/data/game.ts
@@ -10,5 +10,6 @@ export type Game = {
     initialData: InitialData
     languages: Record<string, string>
     pages: Record<string, string>
+    tiles: Record<string, string>
     handlers: string[]
 }

--- a/src/loader/data/tile.ts
+++ b/src/loader/data/tile.ts
@@ -1,0 +1,11 @@
+export type Tile = {
+    key: string
+    description: string
+    color: string
+    image?: string
+}
+
+export type TileSet = {
+    id: string
+    tiles: Tile[]
+}

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -8,6 +8,8 @@ import { type Page as PageData } from './data/page'
 import { pageLoader } from './pageLoader'
 import type { Handlers } from './data/handler'
 import { handlerLoader } from './handlerLoader'
+import type { TileSet as TileSetData } from './data/tile'
+import { tileLoader } from './tileLoader'
 
 export interface ILoader {
     loadPage(page: string): Promise<PageData>
@@ -17,6 +19,7 @@ export interface ILoader {
     get Styling(): string[]
     loadLanguage(language: string): Promise<LanguageData>
     loadHandlers(path: string): Promise<Handlers>
+    loadTileSet(id: string): Promise<TileSetData>
 }
 
 export class Loader implements ILoader {
@@ -27,6 +30,7 @@ export class Loader implements ILoader {
     private languages: Map<string, LanguageData> = new Map()
     private pages: Map<string, PageData> = new Map()
     private handlers: Map<string, Handlers> = new Map()
+    private tileSets: Map<string, TileSetData> = new Map()
 
     constructor(basePath: string = '/data') {
         this.basePath = basePath
@@ -41,6 +45,7 @@ export class Loader implements ILoader {
         this.languages.clear()
         this.pages.clear()
         this.handlers.clear()
+        this.tileSets.clear()
         this.root = await loadJsonResource(`${this.basePath}/index.json`, gameSchema)
         this.styling = this.root.styling.map(css => `${this.basePath}/${css}`)
         this.game = {
@@ -53,6 +58,7 @@ export class Loader implements ILoader {
             },
             languages: this.root.languages,
             pages: this.root.pages,
+            tiles: this.root.tiles ?? {},
             handlers: this.root.handlers
         }
     }
@@ -74,6 +80,14 @@ export class Loader implements ILoader {
         if (this.pages.has(page)) return this.pages.get(page)!
         const path = this.game?.pages[page] ?? fatalError('Unknown page: {0}', page)
         return pageLoader({basePath: this.basePath, path}, result => this.pages.set(page, result))
+    }
+
+    public async loadTileSet(id: string): Promise<TileSetData> {
+        if (this.tileSets.has(id)) return this.tileSets.get(id)!
+        const path = this.game?.tiles[id] ?? fatalError('Unknown tile set: {0}', id)
+        const tileSet = await tileLoader({ basePath: this.basePath, path })
+        this.tileSets.set(id, tileSet)
+        return tileSet
     }
 
     public async loadHandlers(path: string): Promise<Handlers> {

--- a/src/loader/schema/game.ts
+++ b/src/loader/schema/game.ts
@@ -12,6 +12,7 @@ export const gameSchema = z.object({
     'initial-data': initialDataSchema,
     languages: z.record(z.string(), z.string()),
     pages: z.record(z.string(), z.string()),
+    tiles: z.record(z.string(), z.string()),
     styling: z.array(z.string()),
     handlers: z.array(z.string())
 })

--- a/src/loader/schema/tile.ts
+++ b/src/loader/schema/tile.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const tileSchema = z.object({
+    key: z.string(),
+    description: z.string(),
+    color: z.string(),
+    image: z.string().optional()
+})
+
+export const tileSetSchema = z.object({
+    id: z.string(),
+    tiles: z.array(tileSchema)
+})
+
+export type Tile = z.infer<typeof tileSchema>
+export type TileSet = z.infer<typeof tileSetSchema>

--- a/src/loader/tileLoader.ts
+++ b/src/loader/tileLoader.ts
@@ -1,0 +1,33 @@
+import { loadJsonResource } from '@utils/loadJsonResource'
+import type { TileSet as TileSetData, Tile as TileData } from './data/tile'
+import { tileSetSchema, type TileSet as SchemaTileSet, type Tile as SchemaTile } from './schema/tile'
+
+function getDirectory(path: string): string {
+    const idx = path.lastIndexOf('/')
+    if (idx === -1) return ''
+    return path.substring(0, idx)
+}
+
+interface Context {
+    basePath: string
+    path: string
+}
+
+export async function tileLoader(context: Context): Promise<TileSetData> {
+    const schemaData = await loadJsonResource<SchemaTileSet>(`${context.basePath}/${context.path}`, tileSetSchema)
+    const dir = getDirectory(context.path)
+    const prefix = dir ? `${context.basePath}/${dir}` : context.basePath
+    return {
+        id: schemaData.id,
+        tiles: schemaData.tiles.map(t => getTile(prefix, t))
+    }
+}
+
+function getTile(prefix: string, tile: SchemaTile): TileData {
+    return {
+        key: tile.key,
+        description: tile.description,
+        color: tile.color,
+        image: tile.image ? `${prefix}/${tile.image}` : undefined
+    }
+}

--- a/test/app/screen.test.tsx
+++ b/test/app/screen.test.tsx
@@ -20,9 +20,9 @@ describe('Screen', () => {
     const child = (element.props.children as React.ReactElement<Record<string, unknown>>[])[0]
     const style = child.props.style as Record<string, string>
 
-    expect(style['--grid-top']).toBe('2')
-    expect(style['--grid-left']).toBe('3')
-    expect(style['--grid-right']).toBe('4')
-    expect(style['--grid-bottom']).toBe('5')
+    expect(style['--ge-grid-item-top']).toBe('2')
+    expect(style['--ge-grid-item-left']).toBe('3')
+    expect(style['--ge-grid-item-right']).toBe('4')
+    expect(style['--ge-grid-item-bottom']).toBe('5')
   })
 })


### PR DESCRIPTION
## Summary
- define `Tile` and `TileSet` data
- load tiles lazily in loader
- extend game schema/data with `tiles`
- update game editor and tests

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b8704b0a883328eb5514e6a8fe9e4