### PR TITLE
Add map data & loader

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -22,6 +22,7 @@ export const GameEditor: React.FC = () => {
           },
           languages: { ...parsed.languages },
           pages: { ...parsed.pages },
+          maps: { ...parsed.maps },
           tiles: { ...parsed.tiles },
           handlers: [...parsed.handlers],
         }
@@ -36,6 +37,7 @@ export const GameEditor: React.FC = () => {
           initialData: { language: '', startPage: '' },
           languages: {},
           pages: {},
+          maps: {},
           tiles: {},
           handlers: [],
         })
@@ -91,6 +93,7 @@ export const GameEditor: React.FC = () => {
       },
       languages: game.languages,
       pages: game.pages,
+      maps: game.maps,
       tiles: game.tiles,
       styling,
       handlers: game.handlers,

--- a/src/loader/data/game.ts
+++ b/src/loader/data/game.ts
@@ -10,6 +10,7 @@ export type Game = {
     initialData: InitialData
     languages: Record<string, string>
     pages: Record<string, string>
+    maps: Record<string, string>
     tiles: Record<string, string>
     handlers: string[]
 }

--- a/src/loader/data/map.ts
+++ b/src/loader/data/map.ts
@@ -1,0 +1,16 @@
+export type MapTile = {
+    key: string
+    tile: string
+}
+
+export interface SquaresMap {
+    key: string
+    type: 'squares-map'
+    width: number
+    height: number
+    tileSets: string[]
+    tiles: MapTile[]
+    map: string[][]
+}
+
+export type GameMap = SquaresMap

--- a/src/loader/mapLoader.ts
+++ b/src/loader/mapLoader.ts
@@ -1,0 +1,32 @@
+import { loadJsonResource } from '@utils/loadJsonResource'
+import type { GameMap as MapData, MapTile as MapTileData } from './data/map'
+import { squaresMapSchema, type SquaresMap as SchemaSquaresMap, type MapTile as SchemaMapTile } from './schema/map'
+
+interface Context {
+    basePath: string
+    path: string
+}
+
+export async function mapLoader(context: Context): Promise<MapData> {
+    const schemaData = await loadJsonResource<SchemaSquaresMap>(`${context.basePath}/${context.path}`, squaresMapSchema)
+    return getMap(schemaData)
+}
+
+function getMap(map: SchemaSquaresMap): MapData {
+    return {
+        key: map.key,
+        type: 'squares-map',
+        width: map.width,
+        height: map.height,
+        tileSets: map.tileSets,
+        tiles: map.tiles.map(getMapTile),
+        map: map.map.map(row => row.split(',')),
+    }
+}
+
+function getMapTile(tile: SchemaMapTile): MapTileData {
+    return {
+        key: tile.key,
+        tile: tile.tile,
+    }
+}

--- a/src/loader/schema/game.ts
+++ b/src/loader/schema/game.ts
@@ -12,6 +12,7 @@ export const gameSchema = z.object({
     'initial-data': initialDataSchema,
     languages: z.record(z.string(), z.string()),
     pages: z.record(z.string(), z.string()),
+    maps: z.record(z.string(), z.string()),
     tiles: z.record(z.string(), z.string()),
     styling: z.array(z.string()),
     handlers: z.array(z.string())

--- a/src/loader/schema/map.ts
+++ b/src/loader/schema/map.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const mapTileSchema = z.object({
+    key: z.string(),
+    tile: z.string(),
+})
+
+export const squaresMapSchema = z.object({
+    key: z.string(),
+    type: z.literal('squares-map'),
+    width: z.number(),
+    height: z.number(),
+    tileSets: z.array(z.string()),
+    tiles: z.array(mapTileSchema),
+    map: z.array(z.string()),
+})
+
+export type MapTile = z.infer<typeof mapTileSchema>
+export type SquaresMap = z.infer<typeof squaresMapSchema>
+export type GameMap = SquaresMap


### PR DESCRIPTION
## Summary
- define GameMap types and map schema
- add map loader and wire into Loader
- parse maps in GameEditor
- test map caching in the Loader
- split map strings into a 2D array when loading

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b8d8c0f6c833292823391bfa0e9c6