### PR TITLE
Track object changes in state manager

### DIFF
--- a/src/engine/changeTracker.ts
+++ b/src/engine/changeTracker.ts
@@ -1,6 +1,6 @@
 import { setValueAtPath } from '@utils/objectPath'
 
-export type Primitive = string | number | boolean | null
+export type Primitive = string | number | boolean | null | Record<string, unknown> | unknown[]
 
 export type ChangeInfo = {
     path: string,

--- a/src/engine/mapManager.ts
+++ b/src/engine/mapManager.ts
@@ -8,11 +8,9 @@ export interface IMapManager {
 }
 
 export class MapManager implements IMapManager {
-    private gameEngine: IGameEngine
     private unregisterEventHandlers: (() => void)[] = []
 
     constructor(gameEngine: IGameEngine){
-        this.gameEngine = gameEngine
         this.unregisterEventHandlers.push(
             gameEngine.MessageBus.registerMessageListener(
                 SWITCH_MAP_MESSAGE,

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -26,7 +26,8 @@ function createTestEngine() {
     get TranslationService() { return {} as any },
     get Loader() { return loader as any },
     get MessageBus() { return messageBus as any },
-    get PageManager(): IPageManager { return {} as IPageManager }
+    get PageManager(): IPageManager { return {} as IPageManager },
+    get MapManager() { return {} as any }
   }
 
   const pageManager = new PageManager(engine)

--- a/test/engine/stateManager.test.ts
+++ b/test/engine/stateManager.test.ts
@@ -35,4 +35,24 @@ describe('StateManager', () => {
     manager2.rollbackTurn()
     expect(manager2.state.count).toBe(1)
   })
+
+  it('tracks object assignments and rollbacks nested changes', () => {
+    interface ObjData extends Record<string, unknown> { player: { id: string } | null }
+
+    const tracker = new ChangeTracker<ObjData>()
+    const manager = new StateManager<ObjData>({ player: null }, tracker)
+
+    manager.state.player = { id: 'p1' }
+    manager.commitTurn()
+    const save = manager.save()
+
+    const tracker2 = new ChangeTracker<ObjData>()
+    const manager2 = new StateManager<ObjData>({ player: null }, tracker2)
+    manager2.load(save)
+    expect(manager2.state.player).toEqual({ id: 'p1' })
+
+    manager2.state.player!.id = 'p2'
+    manager2.rollbackTurn()
+    expect(manager2.state.player).toEqual({ id: 'p1' })
+  })
 })


### PR DESCRIPTION
## Summary
- expand `Primitive` to include objects and arrays
- remove unused `gameEngine` property from `MapManager`
- record object assignments in `StateManager` setter
- satisfy new `IGameEngine` requirement in `pageManager.test`
- test saving, loading and rolling back object state changes

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688cd478ecec8332908eb32b24842175