### PR TITLE
Fix failing tests

### DIFF
--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -14,13 +14,25 @@ function createTestEngine() {
     registerMessageListener: vi.fn().mockReturnValue(() => {}),
     postMessage: vi.fn()
   }
-  const stateManager = new StateManager<ContextData>({ language: 'en', pages: {}, data: { activePage: null } }, new ChangeTracker<ContextData>())
+  const stateManager = new StateManager<ContextData>({
+    language: 'en',
+    pages: {},
+    maps: {},
+    tileSets: {},
+    data: { activePage: null }
+  }, new ChangeTracker<ContextData>())
   const state = new TrackedValue<GameEngineState>('state', GameEngineState.init)
 
   const engine: IGameEngine = {
     async start() {},
     cleanup() {},
     executeAction: vi.fn(),
+    setIsLoading() {
+      state.value = GameEngineState.loading
+    },
+    setIsRunning() {
+      state.value = GameEngineState.running
+    },
     get StateManager() { return stateManager },
     get State() { return state },
     get TranslationService() { return {} as any },


### PR DESCRIPTION
## Summary
- extend mock GameEngine in `pageManager` tests
- update context initialization with missing keys

## Testing
- `npm run test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ce0f8ba1c8332afaa2383252f4778