### PR TITLE
Fix failing loader test

### DIFF
--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -18,8 +18,9 @@ function createTestEngine() {
     language: 'en',
     pages: {},
     maps: {},
+    tiles: {},
     tileSets: {},
-    data: { activePage: null }
+    data: { activePage: null, activeMap: null }
   }, new ChangeTracker<ContextData>())
   const state = new TrackedValue<GameEngineState>('state', GameEngineState.init)
 

--- a/test/loader/loader.test.ts
+++ b/test/loader/loader.test.ts
@@ -33,13 +33,23 @@ const tileSetData = {
   ]
 }
 
-const mapData = {
+const mapSchemaData = {
   key: 'start',
   type: 'squares-map',
   width: 1,
   height: 1,
   tileSets: [],
   tiles: [],
+  map: [] as string[]
+}
+
+const mapData = {
+  key: 'start',
+  type: 'squares-map',
+  width: 1,
+  height: 1,
+  tileSets: [],
+  tiles: {},
   map: [] as string[][]
 }
 
@@ -147,7 +157,7 @@ describe('Loader', () => {
         return { ok: true, json: vi.fn().mockResolvedValue(rootData) } as any
       }
       if (url.endsWith('/start.json')) {
-        return { ok: true, json: vi.fn().mockResolvedValue(mapData) } as any
+        return { ok: true, json: vi.fn().mockResolvedValue(mapSchemaData) } as any
       }
       throw new Error(`Unexpected url ${url}`)
     })


### PR DESCRIPTION
## Summary
- correct map caching test to expect tile objects
- update PageManager test state initialization

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0d8583b083329825df69dbff4562