### PR TITLE
Fix stale callback cleanup

### DIFF
--- a/src/engine/mapManager.ts
+++ b/src/engine/mapManager.ts
@@ -24,6 +24,7 @@ export class MapManager implements IMapManager {
 
     public cleanup(): void {
         this.unregisterEventHandlers.forEach(unregister => unregister())
+        this.unregisterEventHandlers = []
     }
 
     public async switchMap(map: string): Promise<void> {

--- a/src/engine/pageManager.ts
+++ b/src/engine/pageManager.ts
@@ -23,6 +23,7 @@ export class PageManager implements IPageManager {
 
     public cleanup(): void {
         this.unregisterEventHandlers.forEach(unregister => unregister())
+        this.unregisterEventHandlers = []
     }
 
     public async switchPage(page: string): Promise<void> {


### PR DESCRIPTION
## Summary
- ensure map and page managers drop event handlers after cleanup

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688d2aeb12108332adfd94de5130a97e