### PR TITLE
Rename schema handlers type

### DIFF
--- a/src/loader/handlerLoader.ts
+++ b/src/loader/handlerLoader.ts
@@ -1,6 +1,6 @@
 import { loadJsonResource } from '@utils/loadJsonResource'
 import type { Handlers, Handler } from './data/handler'
-import { handlersSchema, type handlers as SchemaHandlers, type Handler as SchemaHandler } from './schema/handler'
+import { handlersSchema, type Handlers as SchemaHandlers, type Handler as SchemaHandler } from './schema/handler'
 import type { Action as ActionData } from './data/action'
 import type { Action } from './schema/action'
 import { fatalError } from '@utils/logMessage'

--- a/src/loader/schema/handler.ts
+++ b/src/loader/schema/handler.ts
@@ -9,4 +9,4 @@ export const handlerSchema = z.object({
 export const handlersSchema = z.array(handlerSchema)
 
 export type Handler = z.infer<typeof handlerSchema>
-export type handlers = z.infer<typeof handlersSchema>
+export type Handlers = z.infer<typeof handlersSchema>


### PR DESCRIPTION
## Summary
- rename `handlers` type in `handler.ts` to `Handlers`
- update imports that referenced this type

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688d2b0496648332a27bb5b4db9b88c3