### PR TITLE
refactor loader caching with reusable helper

### DIFF
--- a/src/loader/pageLoader.ts
+++ b/src/loader/pageLoader.ts
@@ -14,14 +14,12 @@ interface Context {
     path: string
 }
 
-export async function pageLoader(context: Context, update: (page: PageData) => void): Promise<PageData> {
+export async function pageLoader(context: Context): Promise<PageData> {
     const schemaData = await loadJsonResource<Page>(`${context.basePath}/${context.path}`, pageSchema)
-    const result: PageData = {
+    return {
         id: schemaData.id,
         screen: getScreenData(context, schemaData.screen),
     }
-    update(result)
-    return result
 }
 
 function getScreenData(context: Context, screen: Screen): ScreenData {


### PR DESCRIPTION
## Summary
- add generic `loadWithCache` to centralize resource caching in loader
- simplify `pageLoader` and adopt cache helper across all loader methods

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ddb972cc083329a09b6a9499ce1a0