### PR TITLE
refactor: extract page mappers

### DIFF
--- a/src/loader/mappers/page.ts
+++ b/src/loader/mappers/page.ts
@@ -1,0 +1,74 @@
+import type { Screen as ScreenData, GridScreenItem as GridScreenItemData } from '@loader/data/page'
+import type { Component as ComponentData } from '@loader/data/component'
+import type { Button as ButtonData } from '@loader/data/button'
+import { type Screen, type GridScreenItem } from '@loader/schema/page'
+import { type Component } from '@loader/schema/component'
+import { type Button } from '@loader/schema/button'
+import { mapAction } from './action'
+
+interface Context {
+    basePath: string
+}
+
+export function mapScreen(context: Context, screen: Screen): ScreenData {
+    switch (screen.type) {
+        case 'grid':
+            return {
+                type: 'grid',
+                width: screen.width,
+                height: screen.height,
+                components: mapGridScreenComponents(context, screen.components)
+            }
+    }
+}
+
+export function mapGridScreenComponents(context: Context, components: GridScreenItem[]): GridScreenItemData[] {
+    return components.map(c => mapGridScreenComponent(context, c))
+}
+
+export function mapGridScreenComponent(context: Context, item: GridScreenItem): GridScreenItemData {
+    return {
+        position: {
+            top: item.position.top,
+            left: item.position.left,
+            right: item.position.right,
+            bottom: item.position.bottom
+        },
+        component: mapComponent(context, item.component)
+    }
+}
+
+export function mapComponent(context: Context, component: Component): ComponentData {
+    switch (component.type) {
+        case 'game-menu':
+            return {
+                type: 'game-menu',
+                buttons: mapButtons(component.buttons)
+            }
+        case 'image':
+            return {
+                type: 'image',
+                image: `${context.basePath}/${component.image}`
+            }
+        case 'squares-map':
+            return {
+                type: 'squares-map',
+                mapSize: {
+                    rows: component.mapSize.rows,
+                    columns: component.mapSize.columns
+                }
+            }
+    }
+}
+
+export function mapButtons(buttons: Button[]): ButtonData[] {
+    return buttons.map(mapButton)
+}
+
+export function mapButton(button: Button): ButtonData {
+    return {
+        label: button.label,
+        action: mapAction(button.action)
+    }
+}
+

--- a/src/loader/pageLoader.ts
+++ b/src/loader/pageLoader.ts
@@ -1,14 +1,8 @@
 import { loadJsonResource } from '@utils/loadJsonResource'
-import type { Page as PageData, Screen as ScreenData, GridScreenItem as GridScreenItemData } from './data/page'
-import type { Component as ComponentData } from './data/component'
-import type { Button as ButtonData } from './data/button'
-import type { Action as Actiondata } from './data/action'
-import { type Page, type Screen, pageSchema, type GridScreenItem } from './schema/page'
-import { type Component } from './data/component'
-import { type Button } from './schema/button'
-import { type Action } from './schema/action'
-import { fatalError } from '@utils/logMessage'
+import type { Page as PageData } from './data/page'
+import { type Page, pageSchema } from './schema/page'
 import { mapInputs } from './mappers/input'
+import { mapScreen } from './mappers/page'
 
 interface Context {
     basePath: string
@@ -19,82 +13,8 @@ export async function pageLoader(context: Context): Promise<PageData> {
     const schemaData = await loadJsonResource<Page>(`${context.basePath}/${context.path}`, pageSchema)
     return {
         id: schemaData.id,
-        screen: getScreenData(context, schemaData.screen),
+        screen: mapScreen(context, schemaData.screen),
         inputs: mapInputs(schemaData.inputs)
     }
 }
 
-function getScreenData(context: Context, screen: Screen): ScreenData {
-    switch (screen.type) {
-        case 'grid':
-            return {
-                type: 'grid',
-                width: screen.width,
-                height: screen.height,
-                components: getGridScreenComponents(context, screen.components)
-            }
-    }
-}
-
-function getGridScreenComponents(context: Context, components: GridScreenItem[]): GridScreenItemData[] {
-    return components.map(c => getGridScreenComponent(context, c))    
-}
-
-function getGridScreenComponent(context: Context, item: GridScreenItem): GridScreenItemData {
-    return {
-        position: {
-            top: item.position.top,
-            left: item.position.left,
-            right: item.position.right,
-            bottom: item.position.bottom
-        },
-        component: getComponent(context, item.component)
-    }
-}
-
-function getComponent(context: Context, component: Component): ComponentData {
-    switch (component.type) {
-        case 'game-menu':
-            return {
-                type: 'game-menu',
-                buttons: getButtons(component.buttons)
-            }
-        case 'image':
-            return {
-                type: 'image',
-                image: `${context.basePath}/${component.image}`  
-            }
-        case 'squares-map':
-            return {
-                type: 'squares-map',
-                mapSize: {
-                    rows: component.mapSize.rows,
-                    columns: component.mapSize.columns
-                }
-            }
-    }
-}
-
-function getButtons(buttons: Button[]): ButtonData[] {
-    return buttons.map(getButton)
-}
-
-function getButton(button: Button): ButtonData {
-    return {
-        label: button.label,
-        action: getAction(button.action)
-    }
-}
-
-function getAction(action: Action): Actiondata {
-    switch(action.type){
-        case 'post-message':
-            return {
-                type: 'post-message',
-                message: action.message,
-                payload: action.payload
-            }
-        default:
-            fatalError('Unsupported action type: {0}', action.type)
-    }
-}


### PR DESCRIPTION
## Summary
- add page mappers for screens, components, and buttons reusing mapAction
- simplify pageLoader to use new page mappers

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688e1ea374408332a5ef6bbbf2a8ec5f