### PR TITLE
feat(loader): add game mapper

### DIFF
--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -14,6 +14,7 @@ import type { GameMap as MapData } from './data/map'
 import { mapLoader } from './mapLoader'
 import type { VirtualKeys as VirtualKeysData, VirtualInputs as VirtualInputsData } from './data/inputs'
 import { virtualKeysLoader, virtualInputsLoader } from './inputsLoader'
+import { mapGame } from './mappers/game'
 
 export interface ILoader {
     loadPage(page: string): Promise<PageData>
@@ -67,23 +68,9 @@ export class Loader implements ILoader {
         this.virtualKeys.clear()
         this.virtualInputs.clear()
         this.root = await loadJsonResource(`${this.basePath}/index.json`, gameSchema)
-        this.styling = this.root.styling.map(css => `${this.basePath}/${css}`)
-        this.game = {
-            title: this.root.title,
-            description: this.root.description,
-            version: this.root.version,
-            initialData: {
-                language: this.root['initial-data'].language,
-                startPage: this.root['initial-data']['start-page']
-            },
-            languages: this.root.languages,
-            pages: this.root.pages,
-            maps: this.root.maps,
-            tiles: this.root.tiles,
-            handlers: this.root.handlers,
-            virtualKeys: this.root['virtual-keys'],
-            virtualInputs: this.root['virtual-inputs']
-        }
+        const { game, styling } = mapGame(this.root, this.basePath)
+        this.game = game
+        this.styling = styling
     }
 
     public async loadLanguage(language: string): Promise<LanguageData> {

--- a/src/loader/mappers/game.ts
+++ b/src/loader/mappers/game.ts
@@ -1,0 +1,24 @@
+import type { Game as GameData } from '@loader/data/game'
+import { type Game } from '@loader/schema/game'
+
+export function mapGame(game: Game, basePath: string): { game: GameData, styling: string[] } {
+    return {
+        game: {
+            title: game.title,
+            description: game.description,
+            version: game.version,
+            initialData: {
+                language: game['initial-data'].language,
+                startPage: game['initial-data']['start-page']
+            },
+            languages: game.languages,
+            pages: game.pages,
+            maps: game.maps,
+            tiles: game.tiles,
+            handlers: game.handlers,
+            virtualKeys: game['virtual-keys'],
+            virtualInputs: game['virtual-inputs']
+        },
+        styling: game.styling.map(css => `${basePath}/${css}`)
+    }
+}


### PR DESCRIPTION
## Summary
- map Game schema to GameData via new mapper
- use game mapper in loader reset

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688e1ebe64508332a6b0ef523ec34f7f