### PR TITLE
style: add editor layout and fix build

### DIFF
--- a/src/editor/editor.css
+++ b/src/editor/editor.css
@@ -1,0 +1,32 @@
+@import "../style/reset.css";
+@import "../style/variables.css";
+
+body {
+    font-size: var(--ge-font-size);
+    font-family: var(--ge-font-family);
+    background-color: var(--ge-background-color);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--ge-font-size) * 0.5);
+    padding: calc(var(--ge-font-size) * 0.5);
+}
+
+#app {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--ge-font-size) * 0.5);
+}
+
+label {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--ge-font-size) * 0.25);
+}
+
+button {
+    align-self: flex-start;
+    padding: calc(var(--ge-font-size) * 0.25) calc(var(--ge-font-size) * 0.5);
+    cursor: pointer;
+}

--- a/src/loader/mappers/input.ts
+++ b/src/loader/mappers/input.ts
@@ -40,7 +40,7 @@ export function mapInputs(inputs: Input[]): InputData[] {
 
 export function mapInput(input: Input): InputData {
     return {
-        virtualInput: input.vitualInput,
+        virtualInput: input.virtualInput,
         preferredRow: input.prefferedRow,
         preferredCol: input.prefferedCol,
         label: input.label,

--- a/test/engine/mapManager.test.ts
+++ b/test/engine/mapManager.test.ts
@@ -43,6 +43,7 @@ function createTestEngine() {
     async start() {},
     cleanup() {},
     executeAction: vi.fn(),
+    resolveCondition: vi.fn().mockReturnValue(true),
     setIsLoading() { state.value = GameEngineState.loading },
     setIsRunning() { state.value = GameEngineState.running },
     get StateManager() { return stateManager },
@@ -52,7 +53,8 @@ function createTestEngine() {
     get MessageBus() { return messageBus as any },
     get PageManager(): IPageManager { return {} as IPageManager },
     get MapManager() { return {} as any },
-    get InputManager() { return {} as any }
+    get InputManager() { return {} as any },
+    get ScriptRunner() { return {} as any }
   }
 
   const mapManager = new MapManager(engine)

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -28,6 +28,7 @@ function createTestEngine() {
     async start() {},
     cleanup() {},
     executeAction: vi.fn(),
+    resolveCondition: vi.fn().mockReturnValue(true),
     setIsLoading() {
       state.value = GameEngineState.loading
     },
@@ -41,7 +42,8 @@ function createTestEngine() {
     get MessageBus() { return messageBus as any },
     get PageManager(): IPageManager { return {} as IPageManager },
     get MapManager() { return {} as any },
-    get InputManager() { return {} as any }
+    get InputManager() { return {} as any },
+    get ScriptRunner() { return {} as any }
   }
 
   const pageManager = new PageManager(engine)


### PR DESCRIPTION
## Summary
- add global styling to the editor using shared variables and reset
- fix typo in input mapper
- extend engine test stubs with missing methods to satisfy type checks

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688e352dda388332b565a61284788a8c