### PR TITLE
feat(editor): manage maps and tiles

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -4,6 +4,8 @@ import type { Game } from '@loader/data/game'
 import { saveGame } from '../main'
 import { LanguageList } from './LanguageList'
 import { PageList } from './PageList'
+import { MapList } from './MapList'
+import { TileList } from './TileList'
 
 export const GameEditor: React.FC = () => {
   const [game, setGame] = useState<Game | null>(null)
@@ -135,6 +137,90 @@ export const GameEditor: React.FC = () => {
     })
   }
 
+  const updateMapId = (oldId: string, newId: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const maps = { ...g.maps }
+      const path = maps[oldId]
+      delete maps[oldId]
+      maps[newId] = path
+      return { ...g, maps }
+    })
+  }
+
+  const updateMapPath = (id: string, path: string) => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, maps: { ...g.maps, [id]: path } }
+    })
+  }
+
+  const addMap = () => {
+    setGame((g) => {
+      if (!g) return g
+      const maps = { ...g.maps }
+      let newId = ''
+      let i = 1
+      while (Object.prototype.hasOwnProperty.call(maps, newId)) {
+        newId = `new-map-${i}`
+        i += 1
+      }
+      maps[newId] = ''
+      return { ...g, maps }
+    })
+  }
+
+  const removeMap = (id: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const maps = { ...g.maps }
+      delete maps[id]
+      return { ...g, maps }
+    })
+  }
+
+  const updateTileId = (oldId: string, newId: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const tiles = { ...g.tiles }
+      const path = tiles[oldId]
+      delete tiles[oldId]
+      tiles[newId] = path
+      return { ...g, tiles }
+    })
+  }
+
+  const updateTilePath = (id: string, path: string) => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, tiles: { ...g.tiles, [id]: path } }
+    })
+  }
+
+  const addTile = () => {
+    setGame((g) => {
+      if (!g) return g
+      const tiles = { ...g.tiles }
+      let newId = ''
+      let i = 1
+      while (Object.prototype.hasOwnProperty.call(tiles, newId)) {
+        newId = `new-tile-${i}`
+        i += 1
+      }
+      tiles[newId] = ''
+      return { ...g, tiles }
+    })
+  }
+
+  const removeTile = (id: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const tiles = { ...g.tiles }
+      delete tiles[id]
+      return { ...g, tiles }
+    })
+  }
+
   const handleSave = () => {
     if (!game) return
     const obj = {
@@ -226,6 +312,20 @@ export const GameEditor: React.FC = () => {
         updatePagePath={updatePagePath}
         addPage={addPage}
         removePage={removePage}
+      />
+      <MapList
+        maps={game.maps}
+        updateMapId={updateMapId}
+        updateMapPath={updateMapPath}
+        addMap={addMap}
+        removeMap={removeMap}
+      />
+      <TileList
+        tiles={game.tiles}
+        updateTileId={updateTileId}
+        updateTilePath={updateTilePath}
+        addTile={addTile}
+        removeTile={removeTile}
       />
       <button type="button" onClick={handleSave}>
         Save

--- a/src/editor/components/MapList.tsx
+++ b/src/editor/components/MapList.tsx
@@ -1,0 +1,42 @@
+import type React from 'react'
+
+interface MapListProps {
+  maps: Record<string, string>
+  updateMapId: (oldId: string, newId: string) => void
+  updateMapPath: (id: string, path: string) => void
+  addMap: () => void
+  removeMap: (id: string) => void
+}
+
+export const MapList: React.FC<MapListProps> = ({
+  maps,
+  updateMapId,
+  updateMapPath,
+  addMap,
+  removeMap,
+}) => (
+  <section className="editor-section editor-list">
+    <h2>Maps</h2>
+    {Object.entries(maps).map(([id, path]) => (
+      <fieldset key={id} className="editor-list-item">
+        <input
+          type="text"
+          value={id}
+          onChange={(e) => updateMapId(id, e.target.value)}
+        />
+        <input
+          type="text"
+          value={path}
+          onChange={(e) => updateMapPath(id, e.target.value)}
+        />
+        <button type="button" onClick={() => removeMap(id)}>
+          Remove
+        </button>
+      </fieldset>
+    ))}
+    <button type="button" onClick={addMap}>
+      Add Map
+    </button>
+  </section>
+)
+

--- a/src/editor/components/TileList.tsx
+++ b/src/editor/components/TileList.tsx
@@ -1,0 +1,42 @@
+import type React from 'react'
+
+interface TileListProps {
+  tiles: Record<string, string>
+  updateTileId: (oldId: string, newId: string) => void
+  updateTilePath: (id: string, path: string) => void
+  addTile: () => void
+  removeTile: (id: string) => void
+}
+
+export const TileList: React.FC<TileListProps> = ({
+  tiles,
+  updateTileId,
+  updateTilePath,
+  addTile,
+  removeTile,
+}) => (
+  <section className="editor-section editor-list">
+    <h2>Tiles</h2>
+    {Object.entries(tiles).map(([id, path]) => (
+      <fieldset key={id} className="editor-list-item">
+        <input
+          type="text"
+          value={id}
+          onChange={(e) => updateTileId(id, e.target.value)}
+        />
+        <input
+          type="text"
+          value={path}
+          onChange={(e) => updateTilePath(id, e.target.value)}
+        />
+        <button type="button" onClick={() => removeTile(id)}>
+          Remove
+        </button>
+      </fieldset>
+    ))}
+    <button type="button" onClick={addTile}>
+      Add Tile
+    </button>
+  </section>
+)
+

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -19,7 +19,7 @@ beforeAll(() => {
 })
 
 describe('GameEditor', () => {
-  it('adds language and page entries', async () => {
+  it('adds entries for languages, pages, maps, and tiles', async () => {
     const data = {
       title: '',
       description: '',
@@ -48,27 +48,44 @@ describe('GameEditor', () => {
       .find((h) => h.textContent === 'Languages')!.parentElement as HTMLElement
     const pagesSection = Array.from(container.querySelectorAll('h2'))
       .find((h) => h.textContent === 'Pages')!.parentElement as HTMLElement
+    const mapsSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Maps')!.parentElement as HTMLElement
+    const tilesSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Tiles')!.parentElement as HTMLElement
     expect(languagesSection.querySelectorAll('fieldset').length).toBe(0)
     expect(pagesSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(mapsSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(tilesSection.querySelectorAll('fieldset').length).toBe(0)
 
     const addLanguage = Array.from(languagesSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Language'))!
     const addPage = Array.from(pagesSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Page'))!
+    const addMap = Array.from(mapsSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Map'))!
+    const addTile = Array.from(tilesSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Tile'))!
 
     await act(async () => {
       addLanguage.click()
       addPage.click()
+      addMap.click()
+      addTile.click()
       await flushPromises()
     })
-
     expect(languagesSection.querySelectorAll('fieldset').length).toBe(1)
     expect(pagesSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(mapsSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(tilesSection.querySelectorAll('fieldset').length).toBe(1)
 
     const languageInputs = languagesSection.querySelectorAll('fieldset input')
     const pageInputs = pagesSection.querySelectorAll('fieldset input')
+    const mapInputs = mapsSection.querySelectorAll('fieldset input')
+    const tileInputs = tilesSection.querySelectorAll('fieldset input')
     expect((languageInputs[0] as HTMLInputElement).value).toBe('')
     expect((languageInputs[1] as HTMLInputElement).value).toBe('')
     expect((pageInputs[0] as HTMLInputElement).value).toBe('')
     expect((pageInputs[1] as HTMLInputElement).value).toBe('')
+    expect((mapInputs[0] as HTMLInputElement).value).toBe('')
+    expect((mapInputs[1] as HTMLInputElement).value).toBe('')
+    expect((tileInputs[0] as HTMLInputElement).value).toBe('')
+    expect((tileInputs[1] as HTMLInputElement).value).toBe('')
   })
 
   it('removes entries when clicking remove', async () => {
@@ -79,8 +96,8 @@ describe('GameEditor', () => {
       'initial-data': { language: '', 'start-page': '' },
       languages: { en: 'en.json' },
       pages: { start: 'start.json' },
-      maps: {},
-      tiles: {},
+      maps: { world: 'world.json' },
+      tiles: { grass: 'grass.json' },
       styling: [],
       handlers: [],
       'virtual-keys': [],
@@ -100,19 +117,30 @@ describe('GameEditor', () => {
       .find((h) => h.textContent === 'Languages')!.parentElement as HTMLElement
     const pagesSection = Array.from(container.querySelectorAll('h2'))
       .find((h) => h.textContent === 'Pages')!.parentElement as HTMLElement
+    const mapsSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Maps')!.parentElement as HTMLElement
+    const tilesSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Tiles')!.parentElement as HTMLElement
     expect(languagesSection.querySelectorAll('fieldset').length).toBe(1)
     expect(pagesSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(mapsSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(tilesSection.querySelectorAll('fieldset').length).toBe(1)
 
     const removeLang = Array.from(languagesSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
     const removePage = Array.from(pagesSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
+    const removeMap = Array.from(mapsSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
+    const removeTile = Array.from(tilesSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
 
     await act(async () => {
       removeLang.click()
       removePage.click()
+      removeMap.click()
+      removeTile.click()
       await flushPromises()
     })
-
     expect(languagesSection.querySelectorAll('fieldset').length).toBe(0)
     expect(pagesSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(mapsSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(tilesSection.querySelectorAll('fieldset').length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- add MapList and TileList components mirroring LanguageList and PageList
- extend GameEditor with map/tile helpers and integrate new lists
- test adding and removing map/tile entries in GameEditor

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ea4a6e87c83329a168cb6bf056aef