### PR TITLE
Add list editors for game arrays

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -6,6 +6,10 @@ import { LanguageList } from './LanguageList'
 import { PageList } from './PageList'
 import { MapList } from './MapList'
 import { TileList } from './TileList'
+import { StylingList } from './StylingList'
+import { HandlerList } from './HandlerList'
+import { VirtualKeyList } from './VirtualKeyList'
+import { VirtualInputList } from './VirtualInputList'
 
 export const GameEditor: React.FC = () => {
   const [game, setGame] = useState<Game | null>(null)
@@ -221,6 +225,91 @@ export const GameEditor: React.FC = () => {
     })
   }
 
+  const updateStyling = (index: number, value: string) => {
+    setStyling((s) => {
+      const arr = [...s]
+      arr[index] = value
+      return arr
+    })
+  }
+
+  const addStyling = () => {
+    setStyling((s) => [...s, ''])
+  }
+
+  const removeStyling = (index: number) => {
+    setStyling((s) => s.filter((_, i) => i !== index))
+  }
+
+  const updateHandler = (index: number, value: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const handlers = [...g.handlers]
+      handlers[index] = value
+      return { ...g, handlers }
+    })
+  }
+
+  const addHandler = () => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, handlers: [...g.handlers, ''] }
+    })
+  }
+
+  const removeHandler = (index: number) => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, handlers: g.handlers.filter((_, i) => i !== index) }
+    })
+  }
+
+  const updateVirtualKey = (index: number, value: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const virtualKeys = [...g.virtualKeys]
+      virtualKeys[index] = value
+      return { ...g, virtualKeys }
+    })
+  }
+
+  const addVirtualKey = () => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, virtualKeys: [...g.virtualKeys, ''] }
+    })
+  }
+
+  const removeVirtualKey = (index: number) => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, virtualKeys: g.virtualKeys.filter((_, i) => i !== index) }
+    })
+  }
+
+  const updateVirtualInput = (index: number, value: string) => {
+    setGame((g) => {
+      if (!g) return g
+      const virtualInputs = [...g.virtualInputs]
+      virtualInputs[index] = value
+      return { ...g, virtualInputs }
+    })
+  }
+
+  const addVirtualInput = () => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, virtualInputs: [...g.virtualInputs, ''] }
+    })
+  }
+
+  const removeVirtualInput = (index: number) => {
+    setGame((g) => {
+      if (!g) return g
+      return { ...g, virtualInputs: g.virtualInputs.filter((_, i) => i !== index) }
+    })
+  }
+
   const handleSave = () => {
     if (!game) return
     const obj = {
@@ -237,6 +326,8 @@ export const GameEditor: React.FC = () => {
       tiles: game.tiles,
       styling,
       handlers: game.handlers,
+      'virtual-keys': game.virtualKeys,
+      'virtual-inputs': game.virtualInputs,
     }
     const json = JSON.stringify(obj, null, 2)
     void saveGame(json)
@@ -326,6 +417,30 @@ export const GameEditor: React.FC = () => {
         updateTilePath={updateTilePath}
         addTile={addTile}
         removeTile={removeTile}
+      />
+      <StylingList
+        styling={styling}
+        updateStyling={updateStyling}
+        addStyling={addStyling}
+        removeStyling={removeStyling}
+      />
+      <HandlerList
+        handlers={game.handlers}
+        updateHandler={updateHandler}
+        addHandler={addHandler}
+        removeHandler={removeHandler}
+      />
+      <VirtualKeyList
+        virtualKeys={game.virtualKeys}
+        updateVirtualKey={updateVirtualKey}
+        addVirtualKey={addVirtualKey}
+        removeVirtualKey={removeVirtualKey}
+      />
+      <VirtualInputList
+        virtualInputs={game.virtualInputs}
+        updateVirtualInput={updateVirtualInput}
+        addVirtualInput={addVirtualInput}
+        removeVirtualInput={removeVirtualInput}
       />
       <button type="button" onClick={handleSave}>
         Save

--- a/src/editor/components/HandlerList.tsx
+++ b/src/editor/components/HandlerList.tsx
@@ -1,0 +1,35 @@
+import type React from 'react'
+
+interface HandlerListProps {
+  handlers: string[]
+  updateHandler: (index: number, value: string) => void
+  addHandler: () => void
+  removeHandler: (index: number) => void
+}
+
+export const HandlerList: React.FC<HandlerListProps> = ({
+  handlers,
+  updateHandler,
+  addHandler,
+  removeHandler,
+}) => (
+  <section className="editor-section editor-list">
+    <h2>Handlers</h2>
+    {handlers.map((handler, index) => (
+      <fieldset key={index} className="editor-list-item">
+        <input
+          type="text"
+          value={handler}
+          onChange={(e) => updateHandler(index, e.target.value)}
+        />
+        <button type="button" onClick={() => removeHandler(index)}>
+          Remove
+        </button>
+      </fieldset>
+    ))}
+    <button type="button" onClick={addHandler}>
+      Add Handler
+    </button>
+  </section>
+)
+

--- a/src/editor/components/StylingList.tsx
+++ b/src/editor/components/StylingList.tsx
@@ -1,0 +1,35 @@
+import type React from 'react'
+
+interface StylingListProps {
+  styling: string[]
+  updateStyling: (index: number, value: string) => void
+  addStyling: () => void
+  removeStyling: (index: number) => void
+}
+
+export const StylingList: React.FC<StylingListProps> = ({
+  styling,
+  updateStyling,
+  addStyling,
+  removeStyling,
+}) => (
+  <section className="editor-section editor-list">
+    <h2>Styling</h2>
+    {styling.map((path, index) => (
+      <fieldset key={index} className="editor-list-item">
+        <input
+          type="text"
+          value={path}
+          onChange={(e) => updateStyling(index, e.target.value)}
+        />
+        <button type="button" onClick={() => removeStyling(index)}>
+          Remove
+        </button>
+      </fieldset>
+    ))}
+    <button type="button" onClick={addStyling}>
+      Add Styling
+    </button>
+  </section>
+)
+

--- a/src/editor/components/VirtualInputList.tsx
+++ b/src/editor/components/VirtualInputList.tsx
@@ -1,0 +1,35 @@
+import type React from 'react'
+
+interface VirtualInputListProps {
+  virtualInputs: string[]
+  updateVirtualInput: (index: number, value: string) => void
+  addVirtualInput: () => void
+  removeVirtualInput: (index: number) => void
+}
+
+export const VirtualInputList: React.FC<VirtualInputListProps> = ({
+  virtualInputs,
+  updateVirtualInput,
+  addVirtualInput,
+  removeVirtualInput,
+}) => (
+  <section className="editor-section editor-list">
+    <h2>Virtual Inputs</h2>
+    {virtualInputs.map((input, index) => (
+      <fieldset key={index} className="editor-list-item">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => updateVirtualInput(index, e.target.value)}
+        />
+        <button type="button" onClick={() => removeVirtualInput(index)}>
+          Remove
+        </button>
+      </fieldset>
+    ))}
+    <button type="button" onClick={addVirtualInput}>
+      Add Virtual Input
+    </button>
+  </section>
+)
+

--- a/src/editor/components/VirtualKeyList.tsx
+++ b/src/editor/components/VirtualKeyList.tsx
@@ -1,0 +1,35 @@
+import type React from 'react'
+
+interface VirtualKeyListProps {
+  virtualKeys: string[]
+  updateVirtualKey: (index: number, value: string) => void
+  addVirtualKey: () => void
+  removeVirtualKey: (index: number) => void
+}
+
+export const VirtualKeyList: React.FC<VirtualKeyListProps> = ({
+  virtualKeys,
+  updateVirtualKey,
+  addVirtualKey,
+  removeVirtualKey,
+}) => (
+  <section className="editor-section editor-list">
+    <h2>Virtual Keys</h2>
+    {virtualKeys.map((key, index) => (
+      <fieldset key={index} className="editor-list-item">
+        <input
+          type="text"
+          value={key}
+          onChange={(e) => updateVirtualKey(index, e.target.value)}
+        />
+        <button type="button" onClick={() => removeVirtualKey(index)}>
+          Remove
+        </button>
+      </fieldset>
+    ))}
+    <button type="button" onClick={addVirtualKey}>
+      Add Virtual Key
+    </button>
+  </section>
+)
+

--- a/test/editor/stringLists.test.tsx
+++ b/test/editor/stringLists.test.tsx
@@ -1,0 +1,148 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest'
+import { GameEditor } from '../../src/editor/components/GameEditor'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+
+function flushPromises() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+beforeAll(() => {
+  ;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+describe('GameEditor string lists', () => {
+  it('adds entries for styling, handlers, virtual keys, and virtual inputs', async () => {
+    const data = {
+      title: '',
+      description: '',
+      version: '',
+      'initial-data': { language: '', 'start-page': '' },
+      languages: {},
+      pages: {},
+      maps: {},
+      tiles: {},
+      styling: [],
+      handlers: [],
+      'virtual-keys': [],
+      'virtual-inputs': [],
+    }
+    const fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(data) })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    await act(async () => {
+      createRoot(container).render(<GameEditor />)
+      await flushPromises()
+    })
+
+    const stylingSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Styling')!.parentElement as HTMLElement
+    const handlersSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Handlers')!.parentElement as HTMLElement
+    const virtualKeysSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Virtual Keys')!.parentElement as HTMLElement
+    const virtualInputsSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Virtual Inputs')!.parentElement as HTMLElement
+
+    expect(stylingSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(handlersSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(virtualKeysSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(virtualInputsSection.querySelectorAll('fieldset').length).toBe(0)
+
+    const addStyling = Array.from(stylingSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Styling'))!
+    const addHandler = Array.from(handlersSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Handler'))!
+    const addVirtualKey = Array.from(virtualKeysSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Virtual Key'))!
+    const addVirtualInput = Array.from(virtualInputsSection.querySelectorAll('button')).find((b) => b.textContent?.includes('Add Virtual Input'))!
+
+    await act(async () => {
+      addStyling.click()
+      addHandler.click()
+      addVirtualKey.click()
+      addVirtualInput.click()
+      await flushPromises()
+    })
+
+    expect(stylingSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(handlersSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(virtualKeysSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(virtualInputsSection.querySelectorAll('fieldset').length).toBe(1)
+
+    const stylingInput = stylingSection.querySelector('fieldset input') as HTMLInputElement
+    const handlerInput = handlersSection.querySelector('fieldset input') as HTMLInputElement
+    const virtualKeyInput = virtualKeysSection.querySelector('fieldset input') as HTMLInputElement
+    const virtualInput = virtualInputsSection.querySelector('fieldset input') as HTMLInputElement
+
+    expect(stylingInput.value).toBe('')
+    expect(handlerInput.value).toBe('')
+    expect(virtualKeyInput.value).toBe('')
+    expect(virtualInput.value).toBe('')
+  })
+
+  it('removes entries when clicking remove for styling, handlers, virtual keys, and virtual inputs', async () => {
+    const data = {
+      title: '',
+      description: '',
+      version: '',
+      'initial-data': { language: '', 'start-page': '' },
+      languages: {},
+      pages: {},
+      maps: {},
+      tiles: {},
+      styling: ['style.css'],
+      handlers: ['handler.js'],
+      'virtual-keys': ['A'],
+      'virtual-inputs': ['input'],
+    }
+    const fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(data) })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    await act(async () => {
+      createRoot(container).render(<GameEditor />)
+      await flushPromises()
+    })
+
+    const stylingSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Styling')!.parentElement as HTMLElement
+    const handlersSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Handlers')!.parentElement as HTMLElement
+    const virtualKeysSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Virtual Keys')!.parentElement as HTMLElement
+    const virtualInputsSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Virtual Inputs')!.parentElement as HTMLElement
+
+    expect(stylingSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(handlersSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(virtualKeysSection.querySelectorAll('fieldset').length).toBe(1)
+    expect(virtualInputsSection.querySelectorAll('fieldset').length).toBe(1)
+
+    const removeStyling = Array.from(stylingSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
+    const removeHandler = Array.from(handlersSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
+    const removeVirtualKey = Array.from(virtualKeysSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
+    const removeVirtualInput = Array.from(virtualInputsSection.querySelectorAll('button')).find((b) => b.textContent === 'Remove')!
+
+    await act(async () => {
+      removeStyling.click()
+      removeHandler.click()
+      removeVirtualKey.click()
+      removeVirtualInput.click()
+      await flushPromises()
+    })
+
+    expect(stylingSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(handlersSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(virtualKeysSection.querySelectorAll('fieldset').length).toBe(0)
+    expect(virtualInputsSection.querySelectorAll('fieldset').length).toBe(0)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add reusable list editors for styling, handlers, virtual keys, and virtual inputs
- extend GameEditor to manage these arrays and include them in saves
- test adding and removing entries for the new lists

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f018981548332827f9bc0371efc6e