### PR TITLE
Refactor editor lists with reusable helper

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -10,6 +10,7 @@ import { StylingList } from './StylingList'
 import { HandlerList } from './HandlerList'
 import { VirtualKeyList } from './VirtualKeyList'
 import { VirtualInputList } from './VirtualInputList'
+import { useEditableList } from './useEditableList'
 
 export const GameEditor: React.FC = () => {
   const [game, setGame] = useState<Game | null>(null)
@@ -58,259 +59,52 @@ export const GameEditor: React.FC = () => {
         setStyling([])
       })
   }, [])
+  const setMap = <K extends 'languages' | 'pages' | 'maps' | 'tiles'>(key: K) =>
+    (updater: React.SetStateAction<Record<string, string>>) =>
+      setGame((g) => {
+        if (!g) return g
+        const value =
+          typeof updater === 'function' ? updater(g[key]) : updater
+        return { ...g, [key]: value }
+      })
 
-  const updateLanguageId = (oldId: string, newId: string) => {
+  const setArray = <
+    K extends 'handlers' | 'virtualKeys' | 'virtualInputs'
+  >(key: K) => (updater: React.SetStateAction<string[]>) =>
     setGame((g) => {
       if (!g) return g
-      const languages = { ...g.languages }
-      const path = languages[oldId]
-      delete languages[oldId]
-      languages[newId] = path
-      return { ...g, languages }
+      const value =
+        typeof updater === 'function' ? updater(g[key]) : updater
+      return { ...g, [key]: value }
     })
-  }
 
-  const updateLanguagePath = (id: string, path: string) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, languages: { ...g.languages, [id]: path } }
-    })
-  }
+  const languageActions = useEditableList(setMap('languages'), {
+    type: 'map',
+    prefix: 'language',
+  })
+  const pageActions = useEditableList(setMap('pages'), {
+    type: 'map',
+    prefix: 'page',
+  })
+  const mapActions = useEditableList(setMap('maps'), {
+    type: 'map',
+    prefix: 'map',
+  })
+  const tileActions = useEditableList(setMap('tiles'), {
+    type: 'map',
+    prefix: 'tile',
+  })
 
-  const addLanguage = () => {
-    setGame((g) => {
-      if (!g) return g
-      const languages = { ...g.languages }
-      let newId = 'new-language-1'
-      let index = 2
-      while (Object.prototype.hasOwnProperty.call(languages, newId)) {
-        newId = `new-language-${index}`
-        index += 1
-      }
-      languages[newId] = ''
-      return { ...g, languages }
-    })
-  }
-
-  const removeLanguage = (id: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const languages = { ...g.languages }
-      delete languages[id]
-      return { ...g, languages }
-    })
-  }
-
-  const updatePageId = (oldId: string, newId: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const pages = { ...g.pages }
-      const path = pages[oldId]
-      delete pages[oldId]
-      pages[newId] = path
-      return { ...g, pages }
-    })
-  }
-
-  const updatePagePath = (id: string, path: string) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, pages: { ...g.pages, [id]: path } }
-    })
-  }
-
-  const addPage = () => {
-    setGame((g) => {
-      if (!g) return g
-      const pages = { ...g.pages }
-      let newId = 'new-page-1'
-      let i = 2
-      while (Object.prototype.hasOwnProperty.call(pages, newId)) {
-        newId = `new-page-${i}`
-        i += 1
-      }
-      pages[newId] = ''
-      return { ...g, pages }
-    })
-  }
-
-  const removePage = (id: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const pages = { ...g.pages }
-      delete pages[id]
-      return { ...g, pages }
-    })
-  }
-
-  const updateMapId = (oldId: string, newId: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const maps = { ...g.maps }
-      const path = maps[oldId]
-      delete maps[oldId]
-      maps[newId] = path
-      return { ...g, maps }
-    })
-  }
-
-  const updateMapPath = (id: string, path: string) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, maps: { ...g.maps, [id]: path } }
-    })
-  }
-
-  const addMap = () => {
-    setGame((g) => {
-      if (!g) return g
-      const maps = { ...g.maps }
-      let newId = 'new-map-1'
-      let i = 2
-      while (Object.prototype.hasOwnProperty.call(maps, newId)) {
-        newId = `new-map-${i}`
-        i += 1
-      }
-      maps[newId] = ''
-      return { ...g, maps }
-    })
-  }
-
-  const removeMap = (id: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const maps = { ...g.maps }
-      delete maps[id]
-      return { ...g, maps }
-    })
-  }
-
-  const updateTileId = (oldId: string, newId: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const tiles = { ...g.tiles }
-      const path = tiles[oldId]
-      delete tiles[oldId]
-      tiles[newId] = path
-      return { ...g, tiles }
-    })
-  }
-
-  const updateTilePath = (id: string, path: string) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, tiles: { ...g.tiles, [id]: path } }
-    })
-  }
-
-  const addTile = () => {
-    setGame((g) => {
-      if (!g) return g
-      const tiles = { ...g.tiles }
-      let newId = 'new-tile-1'
-      let i = 2
-      while (Object.prototype.hasOwnProperty.call(tiles, newId)) {
-        newId = `new-tile-${i}`
-        i += 1
-      }
-      tiles[newId] = ''
-      return { ...g, tiles }
-    })
-  }
-
-  const removeTile = (id: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const tiles = { ...g.tiles }
-      delete tiles[id]
-      return { ...g, tiles }
-    })
-  }
-
-  const updateStyling = (index: number, value: string) => {
-    setStyling((s) => {
-      const arr = [...s]
-      arr[index] = value
-      return arr
-    })
-  }
-
-  const addStyling = () => {
-    setStyling((s) => [...s, ''])
-  }
-
-  const removeStyling = (index: number) => {
-    setStyling((s) => s.filter((_, i) => i !== index))
-  }
-
-  const updateHandler = (index: number, value: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const handlers = [...g.handlers]
-      handlers[index] = value
-      return { ...g, handlers }
-    })
-  }
-
-  const addHandler = () => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, handlers: [...g.handlers, ''] }
-    })
-  }
-
-  const removeHandler = (index: number) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, handlers: g.handlers.filter((_, i) => i !== index) }
-    })
-  }
-
-  const updateVirtualKey = (index: number, value: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const virtualKeys = [...g.virtualKeys]
-      virtualKeys[index] = value
-      return { ...g, virtualKeys }
-    })
-  }
-
-  const addVirtualKey = () => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, virtualKeys: [...g.virtualKeys, ''] }
-    })
-  }
-
-  const removeVirtualKey = (index: number) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, virtualKeys: g.virtualKeys.filter((_, i) => i !== index) }
-    })
-  }
-
-  const updateVirtualInput = (index: number, value: string) => {
-    setGame((g) => {
-      if (!g) return g
-      const virtualInputs = [...g.virtualInputs]
-      virtualInputs[index] = value
-      return { ...g, virtualInputs }
-    })
-  }
-
-  const addVirtualInput = () => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, virtualInputs: [...g.virtualInputs, ''] }
-    })
-  }
-
-  const removeVirtualInput = (index: number) => {
-    setGame((g) => {
-      if (!g) return g
-      return { ...g, virtualInputs: g.virtualInputs.filter((_, i) => i !== index) }
-    })
-  }
+  const stylingActions = useEditableList(setStyling, { type: 'array' })
+  const handlerActions = useEditableList(setArray('handlers'), {
+    type: 'array',
+  })
+  const virtualKeyActions = useEditableList(setArray('virtualKeys'), {
+    type: 'array',
+  })
+  const virtualInputActions = useEditableList(setArray('virtualInputs'), {
+    type: 'array',
+  })
 
   const handleSave = async () => {
     if (!game) return
@@ -395,57 +189,16 @@ export const GameEditor: React.FC = () => {
           />
         </label>
       </fieldset>
-      <LanguageList
-        languages={game.languages}
-        updateLanguageId={updateLanguageId}
-        updateLanguagePath={updateLanguagePath}
-        addLanguage={addLanguage}
-        removeLanguage={removeLanguage}
-      />
-      <PageList
-        pages={game.pages}
-        updatePageId={updatePageId}
-        updatePagePath={updatePagePath}
-        addPage={addPage}
-        removePage={removePage}
-      />
-      <MapList
-        maps={game.maps}
-        updateMapId={updateMapId}
-        updateMapPath={updateMapPath}
-        addMap={addMap}
-        removeMap={removeMap}
-      />
-      <TileList
-        tiles={game.tiles}
-        updateTileId={updateTileId}
-        updateTilePath={updateTilePath}
-        addTile={addTile}
-        removeTile={removeTile}
-      />
-      <StylingList
-        styling={styling}
-        updateStyling={updateStyling}
-        addStyling={addStyling}
-        removeStyling={removeStyling}
-      />
-      <HandlerList
-        handlers={game.handlers}
-        updateHandler={updateHandler}
-        addHandler={addHandler}
-        removeHandler={removeHandler}
-      />
-      <VirtualKeyList
-        virtualKeys={game.virtualKeys}
-        updateVirtualKey={updateVirtualKey}
-        addVirtualKey={addVirtualKey}
-        removeVirtualKey={removeVirtualKey}
-      />
+      <LanguageList languages={game.languages} {...languageActions} />
+      <PageList pages={game.pages} {...pageActions} />
+      <MapList maps={game.maps} {...mapActions} />
+      <TileList tiles={game.tiles} {...tileActions} />
+      <StylingList styling={styling} {...stylingActions} />
+      <HandlerList handlers={game.handlers} {...handlerActions} />
+      <VirtualKeyList virtualKeys={game.virtualKeys} {...virtualKeyActions} />
       <VirtualInputList
         virtualInputs={game.virtualInputs}
-        updateVirtualInput={updateVirtualInput}
-        addVirtualInput={addVirtualInput}
-        removeVirtualInput={removeVirtualInput}
+        {...virtualInputActions}
       />
       <button type="button" onClick={handleSave} disabled={saving}>
         Save

--- a/src/editor/components/HandlerList.tsx
+++ b/src/editor/components/HandlerList.tsx
@@ -1,17 +1,15 @@
 import type React from 'react'
+import type { EditableArrayActions } from './useEditableList'
 
-interface HandlerListProps {
+interface HandlerListProps extends EditableArrayActions {
   handlers: string[]
-  updateHandler: (index: number, value: string) => void
-  addHandler: () => void
-  removeHandler: (index: number) => void
 }
 
 export const HandlerList: React.FC<HandlerListProps> = ({
   handlers,
-  updateHandler,
-  addHandler,
-  removeHandler,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Handlers</h2>
@@ -20,14 +18,14 @@ export const HandlerList: React.FC<HandlerListProps> = ({
         <input
           type="text"
           value={handler}
-          onChange={(e) => updateHandler(index, e.target.value)}
+          onChange={(e) => updateItem(index, e.target.value)}
         />
-        <button type="button" onClick={() => removeHandler(index)}>
+        <button type="button" onClick={() => removeItem(index)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addHandler}>
+    <button type="button" onClick={addItem}>
       Add Handler
     </button>
   </section>

--- a/src/editor/components/LanguageList.tsx
+++ b/src/editor/components/LanguageList.tsx
@@ -1,19 +1,16 @@
 import type React from 'react'
+import type { EditableMapActions } from './useEditableList'
 
-interface LanguageListProps {
+interface LanguageListProps extends EditableMapActions {
   languages: Record<string, string>
-  updateLanguageId: (oldId: string, newId: string) => void
-  updateLanguagePath: (id: string, path: string) => void
-  addLanguage: () => void
-  removeLanguage: (id: string) => void
 }
 
 export const LanguageList: React.FC<LanguageListProps> = ({
   languages,
-  updateLanguageId,
-  updateLanguagePath,
-  addLanguage,
-  removeLanguage,
+  updateId,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Languages</h2>
@@ -22,19 +19,19 @@ export const LanguageList: React.FC<LanguageListProps> = ({
         <input
           type="text"
           value={id}
-          onChange={(e) => updateLanguageId(id, e.target.value)}
+          onChange={(e) => updateId(id, e.target.value)}
         />
         <input
           type="text"
           value={path}
-          onChange={(e) => updateLanguagePath(id, e.target.value)}
+          onChange={(e) => updateItem(id, e.target.value)}
         />
-        <button type="button" onClick={() => removeLanguage(id)}>
+        <button type="button" onClick={() => removeItem(id)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addLanguage}>
+    <button type="button" onClick={addItem}>
       Add Language
     </button>
   </section>

--- a/src/editor/components/MapList.tsx
+++ b/src/editor/components/MapList.tsx
@@ -1,19 +1,16 @@
 import type React from 'react'
+import type { EditableMapActions } from './useEditableList'
 
-interface MapListProps {
+interface MapListProps extends EditableMapActions {
   maps: Record<string, string>
-  updateMapId: (oldId: string, newId: string) => void
-  updateMapPath: (id: string, path: string) => void
-  addMap: () => void
-  removeMap: (id: string) => void
 }
 
 export const MapList: React.FC<MapListProps> = ({
   maps,
-  updateMapId,
-  updateMapPath,
-  addMap,
-  removeMap,
+  updateId,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Maps</h2>
@@ -22,19 +19,19 @@ export const MapList: React.FC<MapListProps> = ({
         <input
           type="text"
           value={id}
-          onChange={(e) => updateMapId(id, e.target.value)}
+          onChange={(e) => updateId(id, e.target.value)}
         />
         <input
           type="text"
           value={path}
-          onChange={(e) => updateMapPath(id, e.target.value)}
+          onChange={(e) => updateItem(id, e.target.value)}
         />
-        <button type="button" onClick={() => removeMap(id)}>
+        <button type="button" onClick={() => removeItem(id)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addMap}>
+    <button type="button" onClick={addItem}>
       Add Map
     </button>
   </section>

--- a/src/editor/components/PageList.tsx
+++ b/src/editor/components/PageList.tsx
@@ -1,19 +1,16 @@
 import type React from 'react'
+import type { EditableMapActions } from './useEditableList'
 
-interface PageListProps {
+interface PageListProps extends EditableMapActions {
   pages: Record<string, string>
-  updatePageId: (oldId: string, newId: string) => void
-  updatePagePath: (id: string, path: string) => void
-  addPage: () => void
-  removePage: (id: string) => void
 }
 
 export const PageList: React.FC<PageListProps> = ({
   pages,
-  updatePageId,
-  updatePagePath,
-  addPage,
-  removePage,
+  updateId,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Pages</h2>
@@ -22,19 +19,19 @@ export const PageList: React.FC<PageListProps> = ({
         <input
           type="text"
           value={id}
-          onChange={(e) => updatePageId(id, e.target.value)}
+          onChange={(e) => updateId(id, e.target.value)}
         />
         <input
           type="text"
           value={path}
-          onChange={(e) => updatePagePath(id, e.target.value)}
+          onChange={(e) => updateItem(id, e.target.value)}
         />
-        <button type="button" onClick={() => removePage(id)}>
+        <button type="button" onClick={() => removeItem(id)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addPage}>Add Page</button>
+    <button type="button" onClick={addItem}>Add Page</button>
   </section>
 )
 

--- a/src/editor/components/StylingList.tsx
+++ b/src/editor/components/StylingList.tsx
@@ -1,17 +1,15 @@
 import type React from 'react'
+import type { EditableArrayActions } from './useEditableList'
 
-interface StylingListProps {
+interface StylingListProps extends EditableArrayActions {
   styling: string[]
-  updateStyling: (index: number, value: string) => void
-  addStyling: () => void
-  removeStyling: (index: number) => void
 }
 
 export const StylingList: React.FC<StylingListProps> = ({
   styling,
-  updateStyling,
-  addStyling,
-  removeStyling,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Styling</h2>
@@ -20,14 +18,14 @@ export const StylingList: React.FC<StylingListProps> = ({
         <input
           type="text"
           value={path}
-          onChange={(e) => updateStyling(index, e.target.value)}
+          onChange={(e) => updateItem(index, e.target.value)}
         />
-        <button type="button" onClick={() => removeStyling(index)}>
+        <button type="button" onClick={() => removeItem(index)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addStyling}>
+    <button type="button" onClick={addItem}>
       Add Styling
     </button>
   </section>

--- a/src/editor/components/TileList.tsx
+++ b/src/editor/components/TileList.tsx
@@ -1,19 +1,16 @@
 import type React from 'react'
+import type { EditableMapActions } from './useEditableList'
 
-interface TileListProps {
+interface TileListProps extends EditableMapActions {
   tiles: Record<string, string>
-  updateTileId: (oldId: string, newId: string) => void
-  updateTilePath: (id: string, path: string) => void
-  addTile: () => void
-  removeTile: (id: string) => void
 }
 
 export const TileList: React.FC<TileListProps> = ({
   tiles,
-  updateTileId,
-  updateTilePath,
-  addTile,
-  removeTile,
+  updateId,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Tiles</h2>
@@ -22,19 +19,19 @@ export const TileList: React.FC<TileListProps> = ({
         <input
           type="text"
           value={id}
-          onChange={(e) => updateTileId(id, e.target.value)}
+          onChange={(e) => updateId(id, e.target.value)}
         />
         <input
           type="text"
           value={path}
-          onChange={(e) => updateTilePath(id, e.target.value)}
+          onChange={(e) => updateItem(id, e.target.value)}
         />
-        <button type="button" onClick={() => removeTile(id)}>
+        <button type="button" onClick={() => removeItem(id)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addTile}>
+    <button type="button" onClick={addItem}>
       Add Tile
     </button>
   </section>

--- a/src/editor/components/VirtualInputList.tsx
+++ b/src/editor/components/VirtualInputList.tsx
@@ -1,17 +1,15 @@
 import type React from 'react'
+import type { EditableArrayActions } from './useEditableList'
 
-interface VirtualInputListProps {
+interface VirtualInputListProps extends EditableArrayActions {
   virtualInputs: string[]
-  updateVirtualInput: (index: number, value: string) => void
-  addVirtualInput: () => void
-  removeVirtualInput: (index: number) => void
 }
 
 export const VirtualInputList: React.FC<VirtualInputListProps> = ({
   virtualInputs,
-  updateVirtualInput,
-  addVirtualInput,
-  removeVirtualInput,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Virtual Inputs</h2>
@@ -20,14 +18,14 @@ export const VirtualInputList: React.FC<VirtualInputListProps> = ({
         <input
           type="text"
           value={input}
-          onChange={(e) => updateVirtualInput(index, e.target.value)}
+          onChange={(e) => updateItem(index, e.target.value)}
         />
-        <button type="button" onClick={() => removeVirtualInput(index)}>
+        <button type="button" onClick={() => removeItem(index)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addVirtualInput}>
+    <button type="button" onClick={addItem}>
       Add Virtual Input
     </button>
   </section>

--- a/src/editor/components/VirtualKeyList.tsx
+++ b/src/editor/components/VirtualKeyList.tsx
@@ -1,17 +1,15 @@
 import type React from 'react'
+import type { EditableArrayActions } from './useEditableList'
 
-interface VirtualKeyListProps {
+interface VirtualKeyListProps extends EditableArrayActions {
   virtualKeys: string[]
-  updateVirtualKey: (index: number, value: string) => void
-  addVirtualKey: () => void
-  removeVirtualKey: (index: number) => void
 }
 
 export const VirtualKeyList: React.FC<VirtualKeyListProps> = ({
   virtualKeys,
-  updateVirtualKey,
-  addVirtualKey,
-  removeVirtualKey,
+  updateItem,
+  addItem,
+  removeItem,
 }) => (
   <section className="editor-section editor-list">
     <h2>Virtual Keys</h2>
@@ -20,14 +18,14 @@ export const VirtualKeyList: React.FC<VirtualKeyListProps> = ({
         <input
           type="text"
           value={key}
-          onChange={(e) => updateVirtualKey(index, e.target.value)}
+          onChange={(e) => updateItem(index, e.target.value)}
         />
-        <button type="button" onClick={() => removeVirtualKey(index)}>
+        <button type="button" onClick={() => removeItem(index)}>
           Remove
         </button>
       </fieldset>
     ))}
-    <button type="button" onClick={addVirtualKey}>
+    <button type="button" onClick={addItem}>
       Add Virtual Key
     </button>
   </section>

--- a/src/editor/components/useEditableList.ts
+++ b/src/editor/components/useEditableList.ts
@@ -1,0 +1,108 @@
+import { useCallback } from 'react'
+
+export interface EditableMapActions {
+  updateId: (oldId: string, newId: string) => void
+  updateItem: (id: string, value: string) => void
+  addItem: () => void
+  removeItem: (id: string) => void
+}
+
+export interface EditableArrayActions {
+  updateItem: (index: number, value: string) => void
+  addItem: () => void
+  removeItem: (index: number) => void
+}
+
+export function useEditableList(
+  setValue: React.Dispatch<React.SetStateAction<Record<string, string>>>,
+  options: { type: 'map'; prefix: string }
+): EditableMapActions
+export function useEditableList(
+  setValue: React.Dispatch<React.SetStateAction<string[]>>,
+  options: { type: 'array' }
+): EditableArrayActions
+export function useEditableList(
+  setValue: React.Dispatch<
+    React.SetStateAction<Record<string, string> | string[]>
+  >,
+  options: { type: 'map'; prefix: string } | { type: 'array' }
+): EditableMapActions | EditableArrayActions {
+  if (options.type === 'map') {
+    const dispatch = setValue as React.Dispatch<
+      React.SetStateAction<Record<string, string>>
+    >
+    const updateId = useCallback(
+      (oldId: string, newId: string) => {
+        dispatch((curr) => {
+          const map = { ...curr }
+          const value = map[oldId]
+          delete map[oldId]
+          map[newId] = value
+          return map
+        })
+      },
+      [dispatch]
+    )
+
+    const updateItem = useCallback(
+      (id: string, value: string) => {
+        dispatch((curr) => ({ ...curr, [id]: value }))
+      },
+      [dispatch]
+    )
+
+    const addItem = useCallback(() => {
+      dispatch((curr) => {
+        const map = { ...curr }
+        let newId = `new-${options.prefix}-1`
+        let i = 2
+        while (Object.prototype.hasOwnProperty.call(map, newId)) {
+          newId = `new-${options.prefix}-${i}`
+          i += 1
+        }
+        map[newId] = ''
+        return map
+      })
+    }, [dispatch, options.prefix])
+
+    const removeItem = useCallback(
+      (id: string) => {
+        dispatch((curr) => {
+          const map = { ...curr }
+          delete map[id]
+          return map
+        })
+      },
+      [dispatch]
+    )
+
+    return { updateId, updateItem, addItem, removeItem }
+  }
+
+  const dispatch = setValue as React.Dispatch<React.SetStateAction<string[]>>
+
+  const updateItem = useCallback(
+    (index: number, value: string) => {
+      dispatch((curr) => {
+        const arr = [...curr]
+        arr[index] = value
+        return arr
+      })
+    },
+    [dispatch]
+  )
+
+  const addItem = useCallback(() => {
+    dispatch((curr) => [...curr, ''])
+  }, [dispatch])
+
+  const removeItem = useCallback(
+    (index: number) => {
+      dispatch((curr) => curr.filter((_, i) => i !== index))
+    },
+    [dispatch]
+  )
+
+  return { updateItem, addItem, removeItem }
+}
+


### PR DESCRIPTION
## Summary
- add `useEditableList` hook for editable maps and string arrays
- refactor `GameEditor` and list components to use the new helper

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688f14c3b1948332afd51b221cb2468f