### PR TITLE
Fix useEditableList overload types

### DIFF
--- a/src/editor/components/useEditableList.ts
+++ b/src/editor/components/useEditableList.ts
@@ -21,10 +21,10 @@ export function useEditableList(
   setValue: React.Dispatch<React.SetStateAction<string[]>>,
   options: { type: 'array' }
 ): EditableArrayActions
-export function useEditableList(
-  setValue: React.Dispatch<
-    React.SetStateAction<Record<string, string> | string[]>
-  >,
+export function useEditableList<
+  T extends Record<string, string> | string[]
+>(
+  setValue: React.Dispatch<React.SetStateAction<T>>,
   options: { type: 'map'; prefix: string } | { type: 'array' }
 ): EditableMapActions | EditableArrayActions {
   if (options.type === 'map') {


### PR DESCRIPTION
## Summary
- resolve TypeScript overload mismatch in `useEditableList`
- allow both map and array state updates with a generic implementation

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_688f17ee9d248332b1cab3cc332b0b21