### PR TITLE
test: update engine mocks for virtual input handler

### DIFF
--- a/test/engine/mapManager.test.ts
+++ b/test/engine/mapManager.test.ts
@@ -68,6 +68,7 @@ function createTestEngine() {
     get MapManager() { return {} as any },
     get InputManager() { return {} as any },
     get ScriptRunner() { return {} as any },
+    get VirtualInputHandler() { return {} as any },
 
   }
 

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -51,7 +51,8 @@ function createTestEngine() {
     get PageManager(): IPageManager { return {} as IPageManager },
     get MapManager() { return {} as any },
     get InputManager() { return {} as any },
-    get ScriptRunner() { return {} as any }
+    get ScriptRunner() { return {} as any },
+    get VirtualInputHandler() { return {} as any }
   }
 
   const pageManager = new PageManager(engine)


### PR DESCRIPTION
## Summary
- add VirtualInputHandler stub to MapManager and PageManager tests so tsc build passes

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f29994d9c8332b6232c6801abd174