### PR TITLE
feat(editor): add grid-based map editor

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -221,7 +221,11 @@ export const GameEditor: React.FC = () => {
       </fieldset>
       <LanguageList languages={game.languages} {...languageActions} />
       <PageList pages={game.pages} {...pageActions} />
-      <MapList maps={game.maps} {...mapActions} />
+      <MapList
+        maps={game.maps}
+        tiles={Object.keys(game.tiles)}
+        {...mapActions}
+      />
       <TileList tiles={game.tiles} {...tileActions} />
       <StylingList styling={styling} {...stylingActions} />
       <HandlerList handlers={game.handlers} {...handlerActions} />

--- a/src/editor/components/MapEditor.tsx
+++ b/src/editor/components/MapEditor.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react'
+
+interface MapEditorProps {
+  value: string
+  tiles: string[]
+  onChange: (value: string) => void
+}
+
+interface MapData {
+  width: number
+  height: number
+  map: string[][]
+}
+
+const createDefaultMap = (): MapData => ({
+  width: 5,
+  height: 5,
+  map: Array.from({ length: 5 }, () => Array(5).fill('')),
+})
+
+export const MapEditor: React.FC<MapEditorProps> = ({
+  value,
+  tiles,
+  onChange,
+}) => {
+  const [mapData, setMapData] = useState<MapData>(() => {
+    try {
+      const parsed = JSON.parse(value) as MapData
+      if (Array.isArray(parsed.map)) return parsed
+    } catch {
+      /* ignore */
+    }
+    return createDefaultMap()
+  })
+
+  useEffect(() => {
+    try {
+      const parsed = JSON.parse(value) as MapData
+      if (Array.isArray(parsed.map)) {
+        setMapData(parsed)
+        return
+      }
+    } catch {
+      /* ignore */
+    }
+    setMapData(createDefaultMap())
+  }, [value])
+
+  const [selectedTile, setSelectedTile] = useState(tiles[0] ?? '')
+
+  useEffect(() => {
+    setSelectedTile((prev) => (tiles.includes(prev) ? prev : tiles[0] ?? ''))
+  }, [tiles])
+
+  const setCell = (x: number, y: number) => {
+    setMapData((curr) => {
+      const map = curr.map.map((row) => [...row])
+      map[y][x] = selectedTile
+      const updated = { ...curr, map }
+      onChange(JSON.stringify(updated))
+      return updated
+    })
+  }
+
+  return (
+    <div>
+      <select
+        className="tile-picker"
+        value={selectedTile}
+        onChange={(e) => setSelectedTile(e.target.value)}
+      >
+        {tiles.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <div className="map-grid">
+        {mapData.map.map((row, y) => (
+          <div key={y} className="map-row">
+            {row.map((cell, x) => (
+              <button
+                type="button"
+                key={x}
+                className="map-cell"
+                onClick={() => setCell(x, y)}
+              >
+                {cell || '.'}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/editor/components/MapList.tsx
+++ b/src/editor/components/MapList.tsx
@@ -1,94 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import type { EditableMapActions } from './useEditableList'
+import { MapEditor } from './MapEditor'
 
 interface MapListProps extends EditableMapActions {
   maps: Record<string, string>
   tiles: string[]
-}
-
-interface MapData {
-  width: number
-  height: number
-  map: string[][]
-}
-
-const createDefaultMap = (): MapData => ({
-  width: 5,
-  height: 5,
-  map: Array.from({ length: 5 }, () => Array(5).fill('')),
-})
-
-const MapEditor: React.FC<{
-  value: string
-  tiles: string[]
-  onChange: (value: string) => void
-}> = ({ value, tiles, onChange }) => {
-  const [mapData, setMapData] = useState<MapData>(() => {
-    try {
-      const parsed = JSON.parse(value) as MapData
-      if (Array.isArray(parsed.map)) return parsed
-    } catch {
-      /* ignore */
-    }
-    return createDefaultMap()
-  })
-
-  useEffect(() => {
-    try {
-      const parsed = JSON.parse(value) as MapData
-      if (Array.isArray(parsed.map)) {
-        setMapData(parsed)
-        return
-      }
-    } catch {
-      /* ignore */
-    }
-    setMapData(createDefaultMap())
-  }, [value])
-
-  const [selectedTile, setSelectedTile] = useState(tiles[0] ?? '')
-
-  const setCell = (x: number, y: number) => {
-    setMapData((curr) => {
-      const map = curr.map.map((row) => [...row])
-      map[y][x] = selectedTile
-      const updated = { ...curr, map }
-      onChange(JSON.stringify(updated))
-      return updated
-    })
-  }
-
-  return (
-    <div>
-      <select
-        className="tile-picker"
-        value={selectedTile}
-        onChange={(e) => setSelectedTile(e.target.value)}
-      >
-        {tiles.map((t) => (
-          <option key={t} value={t}>
-            {t}
-          </option>
-        ))}
-      </select>
-      <div className="map-grid">
-        {mapData.map.map((row, y) => (
-          <div key={y} className="map-row">
-            {row.map((cell, x) => (
-              <button
-                type="button"
-                key={x}
-                className="map-cell"
-                onClick={() => setCell(x, y)}
-              >
-                {cell || '.'}
-              </button>
-            ))}
-          </div>
-        ))}
-      </div>
-    </div>
-  )
 }
 
 export const MapList: React.FC<MapListProps> = ({

--- a/src/editor/components/MapList.tsx
+++ b/src/editor/components/MapList.tsx
@@ -1,12 +1,99 @@
-import type React from 'react'
+import React, { useEffect, useState } from 'react'
 import type { EditableMapActions } from './useEditableList'
 
 interface MapListProps extends EditableMapActions {
   maps: Record<string, string>
+  tiles: string[]
+}
+
+interface MapData {
+  width: number
+  height: number
+  map: string[][]
+}
+
+const createDefaultMap = (): MapData => ({
+  width: 5,
+  height: 5,
+  map: Array.from({ length: 5 }, () => Array(5).fill('')),
+})
+
+const MapEditor: React.FC<{
+  value: string
+  tiles: string[]
+  onChange: (value: string) => void
+}> = ({ value, tiles, onChange }) => {
+  const [mapData, setMapData] = useState<MapData>(() => {
+    try {
+      const parsed = JSON.parse(value) as MapData
+      if (Array.isArray(parsed.map)) return parsed
+    } catch {
+      /* ignore */
+    }
+    return createDefaultMap()
+  })
+
+  useEffect(() => {
+    try {
+      const parsed = JSON.parse(value) as MapData
+      if (Array.isArray(parsed.map)) {
+        setMapData(parsed)
+        return
+      }
+    } catch {
+      /* ignore */
+    }
+    setMapData(createDefaultMap())
+  }, [value])
+
+  const [selectedTile, setSelectedTile] = useState(tiles[0] ?? '')
+
+  const setCell = (x: number, y: number) => {
+    setMapData((curr) => {
+      const map = curr.map.map((row) => [...row])
+      map[y][x] = selectedTile
+      const updated = { ...curr, map }
+      onChange(JSON.stringify(updated))
+      return updated
+    })
+  }
+
+  return (
+    <div>
+      <select
+        className="tile-picker"
+        value={selectedTile}
+        onChange={(e) => setSelectedTile(e.target.value)}
+      >
+        {tiles.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <div className="map-grid">
+        {mapData.map.map((row, y) => (
+          <div key={y} className="map-row">
+            {row.map((cell, x) => (
+              <button
+                type="button"
+                key={x}
+                className="map-cell"
+                onClick={() => setCell(x, y)}
+              >
+                {cell || '.'}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export const MapList: React.FC<MapListProps> = ({
   maps,
+  tiles,
   updateId,
   updateItem,
   addItem,
@@ -14,17 +101,17 @@ export const MapList: React.FC<MapListProps> = ({
 }) => (
   <section className="editor-section editor-list">
     <h2>Maps</h2>
-    {Object.entries(maps).map(([id, path]) => (
+    {Object.entries(maps).map(([id, json]) => (
       <fieldset key={id} className="editor-list-item">
         <input
           type="text"
           value={id}
           onChange={(e) => updateId(id, e.target.value)}
         />
-        <input
-          type="text"
-          value={path}
-          onChange={(e) => updateItem(id, e.target.value)}
+        <MapEditor
+          value={json}
+          tiles={tiles}
+          onChange={(val) => updateItem(id, val)}
         />
         <button type="button" onClick={() => removeItem(id)}>
           Remove

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -10,8 +10,11 @@ function flushPromises() {
   })
 }
 
+const originalFetch = globalThis.fetch
+
 afterEach(() => {
   vi.restoreAllMocks()
+  globalThis.fetch = originalFetch
 })
 
 beforeAll(() => {
@@ -41,8 +44,9 @@ describe('GameEditor', () => {
 
     const container = document.createElement('div')
     document.body.appendChild(container)
+    const root = createRoot(container)
     await act(async () => {
-      createRoot(container).render(<GameEditor />)
+      root.render(<GameEditor />)
       await flushPromises()
     })
 
@@ -88,6 +92,10 @@ describe('GameEditor', () => {
     expect(mapInputs.length).toBe(1)
     expect((tileInputs[0] as HTMLInputElement).value).toBe('new-tile-1')
     expect((tileInputs[1] as HTMLInputElement).value).toBe('')
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
   })
 
   it('removes entries when clicking remove', async () => {
@@ -112,8 +120,9 @@ describe('GameEditor', () => {
 
     const container = document.createElement('div')
     document.body.appendChild(container)
+    const root = createRoot(container)
     await act(async () => {
-      createRoot(container).render(<GameEditor />)
+      root.render(<GameEditor />)
       await flushPromises()
     })
 
@@ -146,6 +155,10 @@ describe('GameEditor', () => {
     expect(pagesSection.querySelectorAll('fieldset').length).toBe(0)
     expect(mapsSection.querySelectorAll('fieldset').length).toBe(0)
     expect(tilesSection.querySelectorAll('fieldset').length).toBe(0)
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
   })
 
   it('displays status message and disables save button while saving', async () => {
@@ -177,8 +190,9 @@ describe('GameEditor', () => {
 
     const container = document.createElement('div')
     document.body.appendChild(container)
+    const root = createRoot(container)
     await act(async () => {
-      createRoot(container).render(<GameEditor />)
+      root.render(<GameEditor />)
       await flushPromises()
     })
 
@@ -199,5 +213,9 @@ describe('GameEditor', () => {
 
     expect(saveButton.disabled).toBe(false)
     expect(container.textContent).toContain('Saved')
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
   })
 })

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -85,7 +85,7 @@ describe('GameEditor', () => {
     expect((pageInputs[0] as HTMLInputElement).value).toBe('new-page-1')
     expect((pageInputs[1] as HTMLInputElement).value).toBe('')
     expect((mapInputs[0] as HTMLInputElement).value).toBe('new-map-1')
-    expect((mapInputs[1] as HTMLInputElement).value).toBe('')
+    expect(mapInputs.length).toBe(1)
     expect((tileInputs[0] as HTMLInputElement).value).toBe('new-tile-1')
     expect((tileInputs[1] as HTMLInputElement).value).toBe('')
   })

--- a/test/editor/mapEditor.test.tsx
+++ b/test/editor/mapEditor.test.tsx
@@ -1,0 +1,80 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest'
+import { GameEditor } from '../../src/editor/components/GameEditor'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+
+function flushPromises() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+beforeAll(() => {
+  ;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+describe('Map editor', () => {
+  it('updates map json when tiles are placed', async () => {
+    const initialMap = { width: 2, height: 2, map: [['', ''], ['', '']] }
+    const data = {
+      title: '',
+      description: '',
+      version: '',
+      'initial-data': { language: '', 'start-page': '' },
+      languages: {},
+      pages: {},
+      maps: { world: JSON.stringify(initialMap) },
+      tiles: { grass: 'grass.json' },
+      styling: [],
+      handlers: [],
+      'virtual-keys': [],
+      'virtual-inputs': [],
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(data) })
+      .mockResolvedValue({ ok: true })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    await act(async () => {
+      createRoot(container).render(<GameEditor />)
+      await flushPromises()
+    })
+
+    const mapsSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Maps')!.parentElement as HTMLElement
+
+    const select = mapsSection.querySelector('select.tile-picker') as HTMLSelectElement
+    await act(async () => {
+      select.value = 'grass'
+      select.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    const firstCell = mapsSection.querySelector('.map-cell') as HTMLButtonElement
+    await act(async () => {
+      firstCell.click()
+      await flushPromises()
+    })
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Save',
+    ) as HTMLButtonElement
+    await act(async () => {
+      saveButton.click()
+      await flushPromises()
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const body = (fetchMock.mock.calls[1][1] as RequestInit).body as string
+    const saved = JSON.parse(body)
+    const savedMap = JSON.parse(saved.maps.world)
+    expect(savedMap.map[0][0]).toBe('grass')
+  })
+})

--- a/test/editor/mapEditor.test.tsx
+++ b/test/editor/mapEditor.test.tsx
@@ -10,8 +10,11 @@ function flushPromises() {
   })
 }
 
+const originalFetch = globalThis.fetch
+
 afterEach(() => {
   vi.restoreAllMocks()
+  globalThis.fetch = originalFetch
 })
 
 beforeAll(() => {
@@ -43,8 +46,9 @@ describe('Map editor', () => {
 
     const container = document.createElement('div')
     document.body.appendChild(container)
+    const root = createRoot(container)
     await act(async () => {
-      createRoot(container).render(<GameEditor />)
+      root.render(<GameEditor />)
       await flushPromises()
     })
 
@@ -76,5 +80,9 @@ describe('Map editor', () => {
     const saved = JSON.parse(body)
     const savedMap = JSON.parse(saved.maps.world)
     expect(savedMap.map[0][0]).toBe('grass')
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
   })
 })


### PR DESCRIPTION
## Summary
- replace text-based map inputs with visual grid editor
- allow picking tiles from existing tile list and update map JSON
- cover map editing with new unit test

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f5732b754833291e402783e1956b6