### PR TITLE
Handle multiple language files

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -89,7 +89,16 @@ export const GameEditor: React.FC = () => {
     load()
     return () => controller.abort()
   }, [])
-  const setMap = <K extends 'languages' | 'pages' | 'maps' | 'tiles'>(key: K) =>
+  const setLanguageMap = (
+    updater: React.SetStateAction<Record<string, string[]>>,
+  ) =>
+    setGame((g) => {
+      if (!g) return g
+      const value = typeof updater === 'function' ? updater(g.languages) : updater
+      return { ...g, languages: value }
+    })
+
+  const setMap = <K extends 'pages' | 'maps' | 'tiles'>(key: K) =>
     (updater: React.SetStateAction<Record<string, string>>) =>
       setGame((g) => {
         if (!g) return g
@@ -108,21 +117,25 @@ export const GameEditor: React.FC = () => {
       return { ...g, [key]: value }
     })
 
-  const languageActions = useEditableList(setMap('languages'), {
+  const languageActions = useEditableList<string[]>(setLanguageMap, {
     type: 'map',
     prefix: 'language',
+    empty: [],
   })
   const pageActions = useEditableList(setMap('pages'), {
     type: 'map',
     prefix: 'page',
+    empty: '',
   })
   const mapActions = useEditableList(setMap('maps'), {
     type: 'map',
     prefix: 'map',
+    empty: '',
   })
   const tileActions = useEditableList(setMap('tiles'), {
     type: 'map',
     prefix: 'tile',
+    empty: '',
   })
 
   const stylingActions = useEditableList(setStyling, { type: 'array' })

--- a/src/editor/components/LanguageList.tsx
+++ b/src/editor/components/LanguageList.tsx
@@ -1,8 +1,8 @@
 import type React from 'react'
 import type { EditableMapActions } from './useEditableList'
 
-interface LanguageListProps extends EditableMapActions {
-  languages: Record<string, string>
+interface LanguageListProps extends EditableMapActions<string[]> {
+  languages: Record<string, string[]>
 }
 
 export const LanguageList: React.FC<LanguageListProps> = ({
@@ -14,7 +14,7 @@ export const LanguageList: React.FC<LanguageListProps> = ({
 }) => (
   <section className="editor-section editor-list">
     <h2>Languages</h2>
-    {Object.entries(languages).map(([id, path]) => (
+    {Object.entries(languages).map(([id, paths]) => (
       <fieldset key={id} className="editor-list-item">
         <input
           type="text"
@@ -23,8 +23,16 @@ export const LanguageList: React.FC<LanguageListProps> = ({
         />
         <input
           type="text"
-          value={path}
-          onChange={(e) => updateItem(id, e.target.value)}
+          value={paths.join(', ')}
+          onChange={(e) =>
+            updateItem(
+              id,
+              e.target.value
+                .split(',')
+                .map((p) => p.trim())
+                .filter((p) => p.length > 0),
+            )
+          }
         />
         <button type="button" onClick={() => removeItem(id)}>
           Remove

--- a/src/editor/components/useEditableList.ts
+++ b/src/editor/components/useEditableList.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
 
-export interface EditableMapActions {
+export interface EditableMapActions<T = string> {
   updateId: (oldId: string, newId: string) => void
-  updateItem: (id: string, value: string) => void
+  updateItem: (id: string, value: T) => void
   addItem: () => void
   removeItem: (id: string) => void
 }
@@ -13,23 +13,23 @@ export interface EditableArrayActions {
   removeItem: (index: number) => void
 }
 
-export function useEditableList(
-  setValue: React.Dispatch<React.SetStateAction<Record<string, string>>>,
-  options: { type: 'map'; prefix: string }
-): EditableMapActions
+export function useEditableList<V>(
+  setValue: React.Dispatch<React.SetStateAction<Record<string, V>>>,
+  options: { type: 'map'; prefix: string; empty: V }
+): EditableMapActions<V>
 export function useEditableList(
   setValue: React.Dispatch<React.SetStateAction<string[]>>,
   options: { type: 'array' }
 ): EditableArrayActions
-export function useEditableList<
-  T extends Record<string, string> | string[]
->(
-  setValue: React.Dispatch<React.SetStateAction<T>>,
-  options: { type: 'map'; prefix: string } | { type: 'array' }
-): EditableMapActions | EditableArrayActions {
+export function useEditableList<V>(
+  setValue:
+    | React.Dispatch<React.SetStateAction<Record<string, V>>>
+    | React.Dispatch<React.SetStateAction<string[]>>,
+  options: { type: 'map'; prefix: string; empty: V } | { type: 'array' },
+): EditableMapActions<V> | EditableArrayActions {
   if (options.type === 'map') {
     const dispatch = setValue as React.Dispatch<
-      React.SetStateAction<Record<string, string>>
+      React.SetStateAction<Record<string, V>>
     >
     const updateId = useCallback(
       (oldId: string, newId: string) => {
@@ -45,7 +45,7 @@ export function useEditableList<
     )
 
     const updateItem = useCallback(
-      (id: string, value: string) => {
+      (id: string, value: V) => {
         dispatch((curr) => ({ ...curr, [id]: value }))
       },
       [dispatch]
@@ -60,10 +60,10 @@ export function useEditableList<
           newId = `new-${options.prefix}-${i}`
           i += 1
         }
-        map[newId] = ''
+        map[newId] = options.empty
         return map
       })
-    }, [dispatch, options.prefix])
+    }, [dispatch, options.prefix, options.empty])
 
     const removeItem = useCallback(
       (id: string) => {

--- a/test/app/screen.test.tsx
+++ b/test/app/screen.test.tsx
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { Screen } from '@app/controls/screen'
 import type { Screen as ScreenData } from '@loader/data/page'
+
+vi.mock('@engine/gameEngine', () => ({
+  getGameEngine: () => ({ resolveCondition: () => true }),
+}))
 
 describe('Screen', () => {
   it('applies grid position variables to components', () => {

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -96,7 +96,7 @@ describe('GameEditor', () => {
       description: '',
       version: '',
       'initial-data': { language: '', 'start-page': '' },
-      languages: { en: 'en.json' },
+      languages: { en: ['en.json'] },
       pages: { start: 'start.json' },
       maps: { world: 'world.json' },
       tiles: { grass: 'grass.json' },

--- a/test/loader/loader.test.ts
+++ b/test/loader/loader.test.ts
@@ -6,7 +6,7 @@ const rootData = {
   description: 'test',
   version: '0.0.1',
   'initial-data': { language: 'en', 'start-page': 'page1' },
-  languages: { en: 'en.json' },
+  languages: { en: ['en.json'] },
   pages: { page1: 'page1.json' },
   maps: { start: 'start.json' },
   tiles: { outdoor: 'tiles.json' },


### PR DESCRIPTION
## Summary
- support multiple files per language in editor
- adjust editable list utility for custom initial values
- align tests with new language array structure and mock game engine in Screen test

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f63731e3483328c631bb3e774e760