### PR TITLE
feat(editor): add map editor component

### DIFF
--- a/src/editor/components/MapEditor.tsx
+++ b/src/editor/components/MapEditor.tsx
@@ -1,0 +1,144 @@
+import { useCallback } from 'react'
+import type React from 'react'
+import { MapViewport } from './MapViewport'
+import { useMapEditor } from './useMapEditor'
+
+export const MapEditor: React.FC = () => {
+  const {
+    map,
+    tiles,
+    selectedTile,
+    tool,
+    canUndo,
+    canRedo,
+    setSelectedTile,
+    setTool,
+    loadFromJSON,
+    saveToJSON,
+    placeTile,
+    undo,
+    redo,
+  } = useMapEditor()
+
+  const handleLoad = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = reader.result
+      if (typeof text === 'string') {
+        loadFromJSON(text)
+      }
+    }
+    reader.readAsText(file)
+  }, [loadFromJSON])
+
+  const handleSave = useCallback(() => {
+    const json = saveToJSON()
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${map?.key ?? 'map'}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [saveToJSON, map])
+
+  const handleTileClick = useCallback((x: number, y: number) => {
+    placeTile(x, y)
+  }, [placeTile])
+
+  return (
+    <section className="editor-section">
+      <h2>Map Editor</h2>
+      <div className="editor-list">
+        <input type="file" accept="application/json" onChange={handleLoad} />
+        <div>
+          <button type="button" onClick={handleSave} disabled={!map}>
+            Save
+          </button>
+          <button type="button" onClick={undo} disabled={!canUndo}>
+            Undo
+          </button>
+          <button type="button" onClick={redo} disabled={!canRedo}>
+            Redo
+          </button>
+          <label>
+            <input
+              type="radio"
+              name="tool"
+              value="brush"
+              checked={tool === 'brush'}
+              onChange={() => setTool('brush')}
+            />
+            Brush
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="tool"
+              value="fill"
+              checked={tool === 'fill'}
+              onChange={() => setTool('fill')}
+            />
+            Fill
+          </label>
+        </div>
+      </div>
+      {map && (
+        <div className="editor-list">
+          <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+            {Object.values(map.tiles).map((mt) => {
+              const tile = tiles[mt.tile]
+              const style: React.CSSProperties = {
+                width: '32px',
+                height: '32px',
+                backgroundColor: tile.color || 'transparent',
+                border: mt.key === selectedTile ? '2px solid red' : '1px solid #ccc',
+                padding: 0,
+              }
+              return (
+                <button
+                  key={mt.key}
+                  type="button"
+                  style={style}
+                  onClick={() => setSelectedTile(mt.key)}
+                >
+                  {tile.image && (
+                    <img src={tile.image} alt={mt.key} style={{ width: '100%', height: '100%' }} />
+                  )}
+                </button>
+              )
+            })}
+          </div>
+          <div style={{ position: 'relative', width: 'fit-content' }}>
+            <MapViewport map={map} tiles={tiles} />
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                display: 'grid',
+                gridTemplateColumns: `repeat(${map.width}, 1fr)`,
+                gridTemplateRows: `repeat(${map.height}, 1fr)`,
+              }}
+            >
+              {map.map.map((row, y) =>
+                row.map((_, x) => (
+                  <div
+                    key={`${x}-${y}`}
+                    onClick={() => handleTileClick(x, y)}
+                    style={{ cursor: 'pointer' }}
+                  />
+                )),
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+

--- a/src/editor/components/useMapEditor.ts
+++ b/src/editor/components/useMapEditor.ts
@@ -1,0 +1,137 @@
+import { useCallback, useState } from 'react'
+import type { GameMap } from '@loader/data/map'
+import type { Tile } from '@loader/data/tile'
+
+export interface UseMapEditorOptions {
+  map?: GameMap
+  tiles?: Record<string, Tile>
+}
+
+export interface MapEditorState {
+  map: GameMap | null
+  tiles: Record<string, Tile>
+  selectedTile: string
+  tool: 'brush' | 'fill'
+  canUndo: boolean
+  canRedo: boolean
+}
+
+export interface MapEditorActions {
+  setSelectedTile: (key: string) => void
+  setTool: (tool: 'brush' | 'fill') => void
+  loadFromJSON: (json: string) => void
+  saveToJSON: () => string
+  placeTile: (x: number, y: number) => void
+  undo: () => void
+  redo: () => void
+}
+
+export function useMapEditor(options: UseMapEditorOptions = {}): MapEditorState & MapEditorActions {
+  const [map, setMap] = useState<GameMap | null>(options.map ?? null)
+  const [tiles, setTiles] = useState<Record<string, Tile>>(options.tiles ?? {})
+  const [selectedTile, setSelectedTile] = useState('')
+  const [tool, setTool] = useState<'brush' | 'fill'>('brush')
+  const [undoStack, setUndoStack] = useState<GameMap[]>([])
+  const [redoStack, setRedoStack] = useState<GameMap[]>([])
+
+  const loadFromJSON = useCallback((json: string) => {
+    const data = JSON.parse(json) as { map: GameMap; tiles: Record<string, Tile> }
+    setMap(data.map)
+    setTiles(data.tiles)
+    setSelectedTile('')
+    setUndoStack([])
+    setRedoStack([])
+  }, [])
+
+  const saveToJSON = useCallback(() => {
+    return JSON.stringify({ map, tiles }, null, 2)
+  }, [map, tiles])
+
+  const pushHistory = useCallback(
+    (newMap: GameMap) => {
+      setUndoStack((curr) => (map ? [...curr, map] : curr))
+      setRedoStack([])
+      setMap(newMap)
+    },
+    [map],
+  )
+
+  const brush = useCallback(
+    (x: number, y: number) => {
+      if (!map || !selectedTile) return
+      const newMap: GameMap = { ...map, map: map.map.map((row) => [...row]) }
+      newMap.map[y][x] = selectedTile
+      pushHistory(newMap)
+    },
+    [map, selectedTile, pushHistory],
+  )
+
+  const fill = useCallback(
+    (x: number, y: number) => {
+      if (!map || !selectedTile) return
+      const target = map.map[y][x]
+      if (target === selectedTile) return
+      const newMap: GameMap = { ...map, map: map.map.map((row) => [...row]) }
+      const width = map.width
+      const height = map.height
+      const stack: Array<{ x: number; y: number }> = [{ x, y }]
+      while (stack.length) {
+        const { x: cx, y: cy } = stack.pop()!
+        if (cx < 0 || cy < 0 || cx >= width || cy >= height) continue
+        if (newMap.map[cy][cx] !== target) continue
+        newMap.map[cy][cx] = selectedTile
+        stack.push({ x: cx + 1, y: cy })
+        stack.push({ x: cx - 1, y: cy })
+        stack.push({ x: cx, y: cy + 1 })
+        stack.push({ x: cx, y: cy - 1 })
+      }
+      pushHistory(newMap)
+    },
+    [map, selectedTile, pushHistory],
+  )
+
+  const placeTile = useCallback(
+    (x: number, y: number) => {
+      if (tool === 'fill') fill(x, y)
+      else brush(x, y)
+    },
+    [tool, brush, fill],
+  )
+
+  const undo = useCallback(() => {
+    setUndoStack((curr) => {
+      if (curr.length === 0) return curr
+      const prev = curr[curr.length - 1]
+      setRedoStack((r) => (map ? [...r, map] : r))
+      setMap(prev)
+      return curr.slice(0, -1)
+    })
+  }, [map])
+
+  const redo = useCallback(() => {
+    setRedoStack((curr) => {
+      if (curr.length === 0) return curr
+      const next = curr[curr.length - 1]
+      setUndoStack((u) => (map ? [...u, map] : u))
+      setMap(next)
+      return curr.slice(0, -1)
+    })
+  }, [map])
+
+  return {
+    map,
+    tiles,
+    selectedTile,
+    tool,
+    canUndo: undoStack.length > 0,
+    canRedo: redoStack.length > 0,
+    setSelectedTile,
+    setTool,
+    loadFromJSON,
+    saveToJSON,
+    placeTile,
+    undo,
+    redo,
+  }
+}
+

--- a/test/editor/useMapEditor.test.tsx
+++ b/test/editor/useMapEditor.test.tsx
@@ -1,0 +1,79 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { useMapEditor } from '../../src/editor/components/useMapEditor'
+
+beforeAll(() => {
+  ;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+describe('useMapEditor', () => {
+  it('supports brush, fill, undo, and redo', () => {
+    const sample = {
+      map: {
+        key: 'test-map',
+        type: 'squares-map' as const,
+        width: 2,
+        height: 2,
+        tileSets: [],
+        tiles: {
+          a: { key: 'a', tile: 'grass' },
+          b: { key: 'b', tile: 'water' },
+        },
+        map: [
+          ['a', 'a'],
+          ['a', 'a'],
+        ],
+      },
+      tiles: {
+        grass: { key: 'grass', description: 'Grass', color: '#0f0' },
+        water: { key: 'water', description: 'Water', color: '#00f' },
+      },
+    }
+
+    let hook: ReturnType<typeof useMapEditor> | null = null
+    const TestComponent: React.FC = () => {
+      hook = useMapEditor()
+      return null
+    }
+    const container = document.createElement('div')
+    act(() => {
+      createRoot(container).render(<TestComponent />)
+    })
+
+    act(() => {
+      hook!.loadFromJSON(JSON.stringify(sample))
+    })
+    act(() => {
+      hook!.setSelectedTile('b')
+    })
+    act(() => {
+      hook!.placeTile(0, 0)
+    })
+    expect(hook!.map!.map[0][0]).toBe('b')
+
+    act(() => {
+      hook!.undo()
+    })
+    expect(hook!.map!.map[0][0]).toBe('a')
+
+    act(() => {
+      hook!.redo()
+    })
+    expect(hook!.map!.map[0][0]).toBe('b')
+
+    act(() => {
+      hook!.setTool('fill')
+    })
+    act(() => {
+      hook!.placeTile(1, 1)
+    })
+    expect(hook!.map!.map.every((row) => row.every((t) => t === 'b'))).toBe(true)
+
+    const json = hook!.saveToJSON()
+    const parsed = JSON.parse(json)
+    expect(parsed.map.map[0][0]).toBe('b')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add `useMapEditor` hook with load/save and undo/redo history
- implement `MapEditor` with tile palette, brush/fill tools, and `MapViewport`
- cover map editing behaviors with tests

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689055ec45f88332ae224e362a333dcc