### PR TITLE
feat(editor): add map editor tab

### DIFF
--- a/src/editor/components/MapList.tsx
+++ b/src/editor/components/MapList.tsx
@@ -3,6 +3,7 @@ import type { EditableMapActions } from './useEditableList'
 
 interface MapListProps extends EditableMapActions {
   maps: Record<string, string>
+  onEdit?: (id: string) => void
 }
 
 export const MapList: React.FC<MapListProps> = ({
@@ -11,6 +12,7 @@ export const MapList: React.FC<MapListProps> = ({
   updateItem,
   addItem,
   removeItem,
+  onEdit,
 }) => (
   <section className="editor-section editor-list">
     <h2>Maps</h2>
@@ -26,6 +28,9 @@ export const MapList: React.FC<MapListProps> = ({
           value={path}
           onChange={(e) => updateItem(id, e.target.value)}
         />
+        <button type="button" onClick={() => onEdit?.(id)}>
+          Edit
+        </button>
         <button type="button" onClick={() => removeItem(id)}>
           Remove
         </button>


### PR DESCRIPTION
## Summary
- add tabs to GameEditor for switching to MapEditor
- allow selecting maps from list and editing them
- save updated map files via existing saveGame flow

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68905fd0077883329e0ef649b7dd55f3