### PR TITLE
Fix map editing by using API endpoint

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -169,7 +169,7 @@ export const GameEditor: React.FC = () => {
     if (!game) return
     const path = game.maps[id]
     try {
-      const res = await fetch(path)
+      const res = await fetch(`/api/map/${encodeURIComponent(path)}`)
       if (!res.ok) throw new Error('failed')
       const mapData: GameMap = await res.json()
       const tiles: Record<string, Tile> = {}
@@ -177,7 +177,9 @@ export const GameEditor: React.FC = () => {
         (mapData.tileSets || []).map(async (setId: string) => {
           const tilePath = game.tiles[setId]
           if (!tilePath) return
-          const tRes = await fetch(tilePath)
+          const tRes = await fetch(
+            `/api/map/${encodeURIComponent(tilePath)}`,
+          )
           if (!tRes.ok) return
           const tJson = await tRes.json()
           if (Array.isArray(tJson.tiles)) {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -39,6 +39,36 @@ export function createApp(fsModule = fs) {
     })
   })
 
+  app.get('/api/map/:path', (req, res) => {
+    const file = req.params.path
+    const mapPath = join(__dirname, '..', '..', gameFolder, file)
+    fsModule.readFile(mapPath, 'utf-8', (err, data) => {
+      if (err) {
+        res.status(500).json({ error: 'Failed to read map' })
+        return
+      }
+      try {
+        const json = JSON.parse(data)
+        res.json(json)
+      } catch {
+        res.status(500).json({ error: 'Invalid JSON' })
+      }
+    })
+  })
+
+  app.post('/api/map/:path', (req, res) => {
+    const file = req.params.path
+    const mapPath = join(__dirname, '..', '..', gameFolder, file)
+    const jsonString = JSON.stringify(req.body, null, 2)
+    fsModule.writeFile(mapPath, jsonString, 'utf-8', (err) => {
+      if (err) {
+        res.status(500).json({ error: 'Failed to save map' })
+        return
+      }
+      res.json({ ok: true })
+    })
+  })
+
   return app
 }
 

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -218,4 +218,60 @@ describe('GameEditor', () => {
     expect(saveButton.disabled).toBe(false)
     expect(container.textContent).toContain('Saved')
   })
+
+  it('opens map editor when clicking edit', async () => {
+    const data = {
+      title: '',
+      description: '',
+      version: '',
+      'initial-data': { language: '', 'start-page': '' },
+      languages: {},
+      pages: {},
+      maps: { world: 'maps/world.json' },
+      tiles: { set1: 'tiles/set1.json' },
+      dialogs: {},
+      styling: [],
+      handlers: [],
+      'virtual-keys': [],
+      'virtual-inputs': [],
+    }
+    const mapData = {
+      key: 'world',
+      type: 'squares-map',
+      width: 1,
+      height: 1,
+      tileSets: ['set1'],
+      tiles: { a: { key: 'a', tile: 'set1.a' } },
+      map: [['a']],
+    }
+    const tilesData = { tiles: [{ key: 'set1.a', color: 'red' }] }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(data) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(mapData) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(tilesData) })
+    ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    await act(async () => {
+      createRoot(container).render(<GameEditor />)
+      await flushPromises()
+    })
+
+    const mapsSection = Array.from(container.querySelectorAll('h2'))
+      .find((h) => h.textContent === 'Maps')!.parentElement as HTMLElement
+    const editButton = Array.from(mapsSection.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Edit',
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      editButton.click()
+      await flushPromises()
+    })
+
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/map/maps%2Fworld.json')
+    expect(fetchMock.mock.calls[2][0]).toBe('/api/map/tiles%2Fset1.json')
+    expect(container.textContent).toContain('Map Editor')
+  })
 })

--- a/test/server/api.test.ts
+++ b/test/server/api.test.ts
@@ -47,4 +47,30 @@ describe('server api', () => {
     expect(res.status).toBe(500)
     expect(res.body).toEqual({ error: 'Failed to save game' })
   })
+
+  it('GET /api/map/:path returns parsed json', async () => {
+    const fsMock = {
+      readFile: vi.fn((_p: string, _e: string, cb: (err: Error | null, data?: string) => void) => cb(null, '{"m":1}')),
+      writeFile: vi.fn(),
+    } as any
+    const app = createApp(fsMock)
+
+    await supertest(app)
+      .get(`/api/map/${encodeURIComponent('maps/test.json')}`)
+      .expect(200, { m: 1 })
+  })
+
+  it('POST /api/map/:path saves data', async () => {
+    const fsMock = {
+      readFile: vi.fn(),
+      writeFile: vi.fn((_p: string, _d: string, _e: string, cb: (err: Error | null) => void) => cb(null)),
+    } as any
+    const app = createApp(fsMock)
+
+    await supertest(app)
+      .post(`/api/map/${encodeURIComponent('maps/test.json')}`)
+      .send({ n: 2 })
+      .expect(200, { ok: true })
+    expect(fsMock.writeFile).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- load map and tiles through API when editing
- add Express routes for reading/writing map files
- test map editor and map API endpoints

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689075d85108833290b564606ae5e712