### PR TITLE
Fix map editor viewport and tile image paths

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -15,6 +15,7 @@ import { VirtualInputList } from './VirtualInputList'
 import { useEditableList } from './useEditableList'
 import type { GameMap, MapTile } from '@loader/data/map'
 import type { Tile } from '@loader/data/tile'
+import { resolveTileSet } from '../resolveTileSet'
 
 export const GameEditor: React.FC = () => {
   const [game, setGame] = useState<Game | null>(null)
@@ -198,9 +199,7 @@ export const GameEditor: React.FC = () => {
           if (!tRes.ok) return
           const tJson = await tRes.json()
           if (Array.isArray(tJson.tiles)) {
-            tJson.tiles.forEach((t: Tile) => {
-              tiles[t.key] = t
-            })
+            Object.assign(tiles, resolveTileSet(tilePath, tJson.tiles as Tile[]))
           }
         }),
       )

--- a/src/editor/components/MapViewport.tsx
+++ b/src/editor/components/MapViewport.tsx
@@ -26,9 +26,9 @@ export interface MapViewportProps {
 
 export const MapViewport: React.FC<MapViewportProps> = ({ map, tiles, viewport, position }) => {
     const viewportSize: ViewportSize = viewport ?? { columns: map.width, rows: map.height }
-    const pos: Position = position ?? { x: 0, y: 0 }
     const deltaX = Math.floor(viewportSize.columns / 2)
     const deltaY = Math.floor(viewportSize.rows / 2)
+    const pos: Position = position ?? { x: deltaX, y: deltaY }
 
     const style: CSSCustomProperties = {
         '--ge-map-viewport-width': viewportSize.columns.toString(),

--- a/src/editor/resolveTileSet.ts
+++ b/src/editor/resolveTileSet.ts
@@ -1,0 +1,22 @@
+import type { Tile } from '@loader/data/tile'
+
+/**
+ * Resolves relative tile image paths to absolute paths inside the game data directory.
+ *
+ * @param tilePath Path to the tile set JSON relative to the game folder
+ * @param tiles Array of tiles loaded from the JSON file
+ * @returns Record of tiles with image paths resolved
+ */
+export function resolveTileSet(tilePath: string, tiles: Tile[]): Record<string, Tile> {
+  const idx = tilePath.lastIndexOf('/')
+  const dir = idx >= 0 ? tilePath.substring(0, idx) : ''
+  const prefix = `/data/${dir}`
+  const result: Record<string, Tile> = {}
+  tiles.forEach((t) => {
+    result[t.key] = {
+      ...t,
+      image: t.image ? `${prefix}/${t.image}` : undefined,
+    }
+  })
+  return result
+}

--- a/test/editor/mapViewport.test.tsx
+++ b/test/editor/mapViewport.test.tsx
@@ -1,0 +1,41 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { MapViewport } from '../../src/editor/components/MapViewport'
+import type { GameMap } from '../../src/loader/data/map'
+import type { Tile } from '../../src/loader/data/tile'
+
+describe('MapViewport', () => {
+  beforeAll(() => {
+    ;(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true
+  })
+  it('defaults position to top-left when none is provided', () => {
+    const tile: Tile = { key: 't', description: '', color: 'red' }
+    const map: GameMap = {
+      key: 'm',
+      type: 'squares-map',
+      width: 2,
+      height: 2,
+      tileSets: [],
+      tiles: {
+        a: { key: 'a', tile: 't' },
+        b: { key: 'b', tile: 't' },
+        c: { key: 'c', tile: 't' },
+        d: { key: 'd', tile: 't' },
+      },
+      map: [
+        ['a', 'b'],
+        ['c', 'd'],
+      ],
+    }
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      createRoot(container).render(<MapViewport map={map} tiles={{ t: tile }} />)
+    })
+    const div = container.querySelector('.squares-map') as HTMLDivElement
+    expect(div.style.getPropertyValue('--ge-map-position-left')).toBe('0')
+    expect(div.style.getPropertyValue('--ge-map-position-top')).toBe('0')
+  })
+})

--- a/test/editor/resolveTileSet.test.ts
+++ b/test/editor/resolveTileSet.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { resolveTileSet } from '../../src/editor/resolveTileSet'
+import type { Tile } from '../../src/loader/data/tile'
+
+describe('resolveTileSet', () => {
+  it('prefixes tile images with /data', () => {
+    const tiles: Tile[] = [
+      { key: 'outdoor.ocean', description: '', color: 'aqua', image: 'outdoor/waves.svg' },
+    ]
+    const result = resolveTileSet('tiles/outdoor.json', tiles)
+    expect(result['outdoor.ocean'].image).toBe('/data/tiles/outdoor/waves.svg')
+  })
+
+  it('handles tiles without images', () => {
+    const tiles: Tile[] = [
+      { key: 'outdoor.beach', description: '', color: 'yellow' },
+    ]
+    const result = resolveTileSet('tiles/outdoor.json', tiles)
+    expect(result['outdoor.beach'].image).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Center map editor viewport by default so full map renders instead of bottom-right corner only
- Resolve tile image paths through new `resolveTileSet` utility and use it when loading tile sets
- Add unit tests for viewport defaulting and tile path resolution

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890abe438548332865898634a9e2852