### PR TITLE
Fix editor input focus loss

### DIFF
--- a/src/editor/components/DialogList.tsx
+++ b/src/editor/components/DialogList.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import type { EditableMapActions } from './useEditableList'
+import { useMapKeys } from './useMapKeys'
 
 interface DialogListProps extends EditableMapActions {
   dialogs: Record<string, string>
@@ -11,27 +12,43 @@ export const DialogList: React.FC<DialogListProps> = ({
   updateItem,
   addItem,
   removeItem,
-}) => (
-  <section className="editor-section editor-list">
-    <h2>Dialogs</h2>
-    {Object.entries(dialogs).map(([id, path]) => (
-      <fieldset key={id} className="editor-list-item">
-        <input
-          type="text"
-          value={id}
-          onChange={(e) => updateId(id, e.target.value)}
-        />
-        <input
-          type="text"
-          value={path}
-          onChange={(e) => updateItem(id, e.target.value)}
-        />
-        <button type="button" onClick={() => removeItem(id)}>
-          Remove
-        </button>
-      </fieldset>
-    ))}
-    <button type="button" onClick={addItem}>Add Dialog</button>
-  </section>
-)
+}) => {
+  const { getKey, updateId: updateKey, removeId } = useMapKeys(
+    Object.keys(dialogs),
+  )
+
+  const handleUpdateId = (oldId: string, newId: string) => {
+    updateKey(oldId, newId)
+    updateId(oldId, newId)
+  }
+
+  const handleRemove = (id: string) => {
+    removeId(id)
+    removeItem(id)
+  }
+
+  return (
+    <section className="editor-section editor-list">
+      <h2>Dialogs</h2>
+      {Object.entries(dialogs).map(([id, path]) => (
+        <fieldset key={getKey(id)} className="editor-list-item">
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => handleUpdateId(id, e.target.value)}
+          />
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => updateItem(id, e.target.value)}
+          />
+          <button type="button" onClick={() => handleRemove(id)}>
+            Remove
+          </button>
+        </fieldset>
+      ))}
+      <button type="button" onClick={addItem}>Add Dialog</button>
+    </section>
+  )
+}
 

--- a/src/editor/components/LanguageList.tsx
+++ b/src/editor/components/LanguageList.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import type { EditableMapActions } from './useEditableList'
+import { useMapKeys } from './useMapKeys'
 
 interface LanguageListProps extends EditableMapActions<string[]> {
   languages: Record<string, string[]>
@@ -11,37 +12,53 @@ export const LanguageList: React.FC<LanguageListProps> = ({
   updateItem,
   addItem,
   removeItem,
-}) => (
-  <section className="editor-section editor-list">
-    <h2>Languages</h2>
-    {Object.entries(languages).map(([id, paths]) => (
-      <fieldset key={id} className="editor-list-item">
-        <input
-          type="text"
-          value={id}
-          onChange={(e) => updateId(id, e.target.value)}
-        />
-        <input
-          type="text"
-          value={paths.join(', ')}
-          onChange={(e) =>
-            updateItem(
-              id,
-              e.target.value
-                .split(',')
-                .map((p) => p.trim())
-                .filter((p) => p.length > 0),
-            )
-          }
-        />
-        <button type="button" onClick={() => removeItem(id)}>
-          Remove
-        </button>
-      </fieldset>
-    ))}
-    <button type="button" onClick={addItem}>
-      Add Language
-    </button>
-  </section>
-)
+}) => {
+  const { getKey, updateId: updateKey, removeId } = useMapKeys(
+    Object.keys(languages),
+  )
+
+  const handleUpdateId = (oldId: string, newId: string) => {
+    updateKey(oldId, newId)
+    updateId(oldId, newId)
+  }
+
+  const handleRemove = (id: string) => {
+    removeId(id)
+    removeItem(id)
+  }
+
+  return (
+    <section className="editor-section editor-list">
+      <h2>Languages</h2>
+      {Object.entries(languages).map(([id, paths]) => (
+        <fieldset key={getKey(id)} className="editor-list-item">
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => handleUpdateId(id, e.target.value)}
+          />
+          <input
+            type="text"
+            value={paths.join(', ')}
+            onChange={(e) =>
+              updateItem(
+                id,
+                e.target.value
+                  .split(',')
+                  .map((p) => p.trim())
+                  .filter((p) => p.length > 0),
+              )
+            }
+          />
+          <button type="button" onClick={() => handleRemove(id)}>
+            Remove
+          </button>
+        </fieldset>
+      ))}
+      <button type="button" onClick={addItem}>
+        Add Language
+      </button>
+    </section>
+  )
+}
 

--- a/src/editor/components/MapList.tsx
+++ b/src/editor/components/MapList.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import type { EditableMapActions } from './useEditableList'
+import { useMapKeys } from './useMapKeys'
 
 interface MapListProps extends EditableMapActions {
   maps: Record<string, string>
@@ -13,32 +14,48 @@ export const MapList: React.FC<MapListProps> = ({
   addItem,
   removeItem,
   onEdit,
-}) => (
-  <section className="editor-section editor-list">
-    <h2>Maps</h2>
-    {Object.entries(maps).map(([id, path]) => (
-      <fieldset key={id} className="editor-list-item">
-        <input
-          type="text"
-          value={id}
-          onChange={(e) => updateId(id, e.target.value)}
-        />
-        <input
-          type="text"
-          value={path}
-          onChange={(e) => updateItem(id, e.target.value)}
-        />
-        <button type="button" onClick={() => onEdit?.(id)}>
-          Edit
-        </button>
-        <button type="button" onClick={() => removeItem(id)}>
-          Remove
-        </button>
-      </fieldset>
-    ))}
-    <button type="button" onClick={addItem}>
-      Add Map
-    </button>
-  </section>
-)
+}) => {
+  const { getKey, updateId: updateKey, removeId } = useMapKeys(
+    Object.keys(maps),
+  )
+
+  const handleUpdateId = (oldId: string, newId: string) => {
+    updateKey(oldId, newId)
+    updateId(oldId, newId)
+  }
+
+  const handleRemove = (id: string) => {
+    removeId(id)
+    removeItem(id)
+  }
+
+  return (
+    <section className="editor-section editor-list">
+      <h2>Maps</h2>
+      {Object.entries(maps).map(([id, path]) => (
+        <fieldset key={getKey(id)} className="editor-list-item">
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => handleUpdateId(id, e.target.value)}
+          />
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => updateItem(id, e.target.value)}
+          />
+          <button type="button" onClick={() => onEdit?.(id)}>
+            Edit
+          </button>
+          <button type="button" onClick={() => handleRemove(id)}>
+            Remove
+          </button>
+        </fieldset>
+      ))}
+      <button type="button" onClick={addItem}>
+        Add Map
+      </button>
+    </section>
+  )
+}
 

--- a/src/editor/components/PageList.tsx
+++ b/src/editor/components/PageList.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import type { EditableMapActions } from './useEditableList'
+import { useMapKeys } from './useMapKeys'
 
 interface PageListProps extends EditableMapActions {
   pages: Record<string, string>
@@ -11,27 +12,43 @@ export const PageList: React.FC<PageListProps> = ({
   updateItem,
   addItem,
   removeItem,
-}) => (
-  <section className="editor-section editor-list">
-    <h2>Pages</h2>
-    {Object.entries(pages).map(([id, path]) => (
-      <fieldset key={id} className="editor-list-item">
-        <input
-          type="text"
-          value={id}
-          onChange={(e) => updateId(id, e.target.value)}
-        />
-        <input
-          type="text"
-          value={path}
-          onChange={(e) => updateItem(id, e.target.value)}
-        />
-        <button type="button" onClick={() => removeItem(id)}>
-          Remove
-        </button>
-      </fieldset>
-    ))}
-    <button type="button" onClick={addItem}>Add Page</button>
-  </section>
-)
+}) => {
+  const { getKey, updateId: updateKey, removeId } = useMapKeys(
+    Object.keys(pages),
+  )
+
+  const handleUpdateId = (oldId: string, newId: string) => {
+    updateKey(oldId, newId)
+    updateId(oldId, newId)
+  }
+
+  const handleRemove = (id: string) => {
+    removeId(id)
+    removeItem(id)
+  }
+
+  return (
+    <section className="editor-section editor-list">
+      <h2>Pages</h2>
+      {Object.entries(pages).map(([id, path]) => (
+        <fieldset key={getKey(id)} className="editor-list-item">
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => handleUpdateId(id, e.target.value)}
+          />
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => updateItem(id, e.target.value)}
+          />
+          <button type="button" onClick={() => handleRemove(id)}>
+            Remove
+          </button>
+        </fieldset>
+      ))}
+      <button type="button" onClick={addItem}>Add Page</button>
+    </section>
+  )
+}
 

--- a/src/editor/components/TileList.tsx
+++ b/src/editor/components/TileList.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import type { EditableMapActions } from './useEditableList'
+import { useMapKeys } from './useMapKeys'
 
 interface TileListProps extends EditableMapActions {
   tiles: Record<string, string>
@@ -11,29 +12,45 @@ export const TileList: React.FC<TileListProps> = ({
   updateItem,
   addItem,
   removeItem,
-}) => (
-  <section className="editor-section editor-list">
-    <h2>Tiles</h2>
-    {Object.entries(tiles).map(([id, path]) => (
-      <fieldset key={id} className="editor-list-item">
-        <input
-          type="text"
-          value={id}
-          onChange={(e) => updateId(id, e.target.value)}
-        />
-        <input
-          type="text"
-          value={path}
-          onChange={(e) => updateItem(id, e.target.value)}
-        />
-        <button type="button" onClick={() => removeItem(id)}>
-          Remove
-        </button>
-      </fieldset>
-    ))}
-    <button type="button" onClick={addItem}>
-      Add Tile
-    </button>
-  </section>
-)
+}) => {
+  const { getKey, updateId: updateKey, removeId } = useMapKeys(
+    Object.keys(tiles),
+  )
+
+  const handleUpdateId = (oldId: string, newId: string) => {
+    updateKey(oldId, newId)
+    updateId(oldId, newId)
+  }
+
+  const handleRemove = (id: string) => {
+    removeId(id)
+    removeItem(id)
+  }
+
+  return (
+    <section className="editor-section editor-list">
+      <h2>Tiles</h2>
+      {Object.entries(tiles).map(([id, path]) => (
+        <fieldset key={getKey(id)} className="editor-list-item">
+          <input
+            type="text"
+            value={id}
+            onChange={(e) => handleUpdateId(id, e.target.value)}
+          />
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => updateItem(id, e.target.value)}
+          />
+          <button type="button" onClick={() => handleRemove(id)}>
+            Remove
+          </button>
+        </fieldset>
+      ))}
+      <button type="button" onClick={addItem}>
+        Add Tile
+      </button>
+    </section>
+  )
+}
 

--- a/src/editor/components/useMapKeys.ts
+++ b/src/editor/components/useMapKeys.ts
@@ -1,0 +1,42 @@
+import { useRef } from 'react'
+
+/**
+ * Maintain stable React keys for editable maps.
+ *
+ * @param ids Current item identifiers
+ * @returns helpers to get keys and update mapping when ids change
+ */
+export function useMapKeys(ids: string[]) {
+  const keyMap = useRef(new Map<string, number>())
+  const nextKey = useRef(0)
+
+  ids.forEach((id) => {
+    if (!keyMap.current.has(id)) {
+      keyMap.current.set(id, nextKey.current++)
+    }
+  })
+
+  const getKey = (id: string) => {
+    let key = keyMap.current.get(id)
+    if (key === undefined) {
+      key = nextKey.current++
+      keyMap.current.set(id, key)
+    }
+    return key
+  }
+
+  const updateId = (oldId: string, newId: string) => {
+    const key = keyMap.current.get(oldId)
+    if (key !== undefined) {
+      keyMap.current.set(newId, key)
+      keyMap.current.delete(oldId)
+    }
+  }
+
+  const removeId = (id: string) => {
+    keyMap.current.delete(id)
+  }
+
+  return { getKey, updateId, removeId }
+}
+


### PR DESCRIPTION
## Summary
- keep editor list items mounted by using stable keys
- introduce `useMapKeys` helper and apply to lists

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d55f61d4833298751dc3b891eb59