### PR TITLE
Fix map editor JSON to match schema

### DIFF
--- a/src/editor/components/useMapEditor.ts
+++ b/src/editor/components/useMapEditor.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import type { GameMap } from '@loader/data/map'
 import type { Tile } from '@loader/data/tile'
+import { fromAnyMap, toSchemaMap } from '../convertMap'
 
 export interface UseMapEditorOptions {
   map?: GameMap
@@ -35,8 +36,8 @@ export function useMapEditor(options: UseMapEditorOptions = {}): MapEditorState 
   const [redoStack, setRedoStack] = useState<GameMap[]>([])
 
   const loadFromJSON = useCallback((json: string) => {
-    const data = JSON.parse(json) as { map: GameMap; tiles: Record<string, Tile> }
-    setMap(data.map)
+    const data = JSON.parse(json) as { map: unknown; tiles: Record<string, Tile> }
+    setMap(fromAnyMap(data.map as GameMap))
     setTiles(data.tiles)
     setSelectedTile('')
     setUndoStack([])
@@ -44,7 +45,8 @@ export function useMapEditor(options: UseMapEditorOptions = {}): MapEditorState 
   }, [])
 
   const saveToJSON = useCallback(() => {
-    return JSON.stringify({ map, tiles }, null, 2)
+    if (!map) return ''
+    return JSON.stringify({ map: toSchemaMap(map), tiles }, null, 2)
   }, [map, tiles])
 
   const pushHistory = useCallback(

--- a/src/editor/convertMap.ts
+++ b/src/editor/convertMap.ts
@@ -1,0 +1,44 @@
+import type { GameMap as DataGameMap, MapTile as DataMapTile } from '@loader/data/map'
+import type { SquaresMap as SchemaSquaresMap } from '@loader/schema/map'
+
+export function toSchemaMap(map: DataGameMap): SchemaSquaresMap {
+  return {
+    key: map.key,
+    type: 'squares-map',
+    width: map.width,
+    height: map.height,
+    tileSets: map.tileSets,
+    tiles: Object.values(map.tiles),
+    map: map.map.map((row) => row.join(',')),
+  }
+}
+
+export function fromAnyMap(map: SchemaSquaresMap | DataGameMap): DataGameMap {
+  if (Array.isArray((map as DataGameMap).map?.[0])) {
+    const data = map as DataGameMap
+    if (Array.isArray((data as unknown as { tiles: unknown }).tiles)) {
+      const tilesArray = (data as unknown as { tiles: DataMapTile[] }).tiles
+      const tilesRecord: Record<string, DataMapTile> = {}
+      tilesArray.forEach((t) => {
+        tilesRecord[t.key] = t
+      })
+      return { ...data, tiles: tilesRecord }
+    }
+    return data
+  }
+
+  const schema = map as SchemaSquaresMap
+  const tilesRecord: Record<string, DataMapTile> = {}
+  schema.tiles.forEach((t) => {
+    tilesRecord[t.key] = t
+  })
+  return {
+    key: schema.key,
+    type: 'squares-map',
+    width: schema.width,
+    height: schema.height,
+    tileSets: schema.tileSets,
+    tiles: tilesRecord,
+    map: schema.map.map((row) => row.split(',')),
+  }
+}

--- a/test/editor/useMapEditor.test.tsx
+++ b/test/editor/useMapEditor.test.tsx
@@ -17,14 +17,11 @@ describe('useMapEditor', () => {
         width: 2,
         height: 2,
         tileSets: [],
-        tiles: {
-          a: { key: 'a', tile: 'grass' },
-          b: { key: 'b', tile: 'water' },
-        },
-        map: [
-          ['a', 'a'],
-          ['a', 'a'],
+        tiles: [
+          { key: 'a', tile: 'grass' },
+          { key: 'b', tile: 'water' },
         ],
+        map: ['a,a', 'a,a'],
       },
       tiles: {
         grass: { key: 'grass', description: 'Grass', color: '#0f0' },
@@ -73,7 +70,9 @@ describe('useMapEditor', () => {
 
     const json = hook!.saveToJSON()
     const parsed = JSON.parse(json)
-    expect(parsed.map.map[0][0]).toBe('b')
+    expect(
+      parsed.map.map.every((row: string) => row.split(',').every((t: string) => t === 'b')),
+    ).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary
- ensure map editor loads and saves maps in schema format
- centralize map data/schema conversion utilities
- test map editor export against schema representation

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6890d5a2fddc8332857ed39c7a4a9e24