### PR TITLE
Add OutputManager mocks for test engine stubs

### DIFF
--- a/test/engine/mapManager.test.ts
+++ b/test/engine/mapManager.test.ts
@@ -69,6 +69,7 @@ function createTestEngine() {
     get InputManager() { return {} as any },
     get ScriptRunner() { return {} as any },
     get VirtualInputHandler() { return {} as any },
+    get OutputManager() { return {} as any },
 
   }
 

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -52,7 +52,8 @@ function createTestEngine() {
     get MapManager() { return {} as any },
     get InputManager() { return {} as any },
     get ScriptRunner() { return {} as any },
-    get VirtualInputHandler() { return {} as any }
+    get VirtualInputHandler() { return {} as any },
+    get OutputManager() { return {} as any }
   }
 
   const pageManager = new PageManager(engine)


### PR DESCRIPTION
## Summary
- mock the OutputManager in MapManager and PageManager unit tests to satisfy IGameEngine

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891053184708332af45e84a37d24396