### PR TITLE
refactor: inject managers into GameEngine

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,14 @@
 import { createRoot } from 'react-dom/client'
 import { logDebug } from '@utils/logMessage'
 import { Loader, type ILoader } from '@loader/loader'
-import { GameEngine, type IGameEngine } from '@engine/gameEngine'
+import { GameEngine, type IGameEngine, type IEngineManagerFactory } from '@engine/gameEngine'
+import { PageManager } from '@engine/pageManager'
+import { MapManager } from '@engine/mapManager'
+import { VirtualInputHandler } from '@engine/virtualInputHandler'
+import { InputManager } from '@engine/inputManager'
+import { OutputManager } from '@engine/outputManager'
+import { DialogManager } from '@engine/dialogManager'
+import { ScriptRunner } from '@engine/scriptRunner'
 import { App } from '@app/app'
 import './style/reset.css'
 import './style/variables.css'
@@ -21,7 +28,17 @@ loader.Styling.forEach(css => {
   document.head.appendChild(link)
 })
 
-const engine: IGameEngine = new GameEngine(loader)
+const factory: IEngineManagerFactory = {
+  createPageManager: (engine) => new PageManager(engine),
+  createMapManager: (engine) => new MapManager(engine),
+  createVirtualInputHandler: (engine) => new VirtualInputHandler(engine),
+  createInputManager: (engine) => new InputManager(engine),
+  createOutputManager: (engine) => new OutputManager(engine),
+  createDialogManager: (engine) => new DialogManager(engine),
+  createScriptRunner: () => new ScriptRunner()
+}
+
+const engine: IGameEngine = new GameEngine(loader, factory)
 await engine.start()
 
 const root = document.getElementById('app')

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -1,11 +1,20 @@
 import { describe, it, expect, vi } from 'vitest'
-import { GameEngine } from '@engine/gameEngine'
+import { GameEngine, type IEngineManagerFactory } from '@engine/gameEngine'
 import type { ILoader } from '@loader/loader'
 import type { Action } from '@loader/data/action'
 
 function createEngine() {
   const loader = {} as unknown as ILoader
-  const engine = new GameEngine(loader)
+  const factory: IEngineManagerFactory = {
+    createPageManager: () => ({ switchPage: vi.fn(), cleanup: vi.fn() }) as any,
+    createMapManager: () => ({ switchMap: vi.fn(), cleanup: vi.fn() }) as any,
+    createVirtualInputHandler: () => ({ cleanup: vi.fn(), load: vi.fn(), getVirtualInput: vi.fn() }) as any,
+    createInputManager: () => ({ cleanup: vi.fn(), update: vi.fn(), getInputMatrix: vi.fn() }) as any,
+    createOutputManager: () => ({ cleanup: vi.fn(), getLastLines: vi.fn() }) as any,
+    createDialogManager: () => ({ cleanup: vi.fn() }) as any,
+    createScriptRunner: () => ({ run: vi.fn() }) as any
+  }
+  const engine = new GameEngine(loader, factory)
   const bus = {
     postMessage: vi.fn(),
     registerMessageListener: vi.fn(),

--- a/test/engine/mapManager.test.ts
+++ b/test/engine/mapManager.test.ts
@@ -70,7 +70,7 @@ function createTestEngine() {
     get ScriptRunner() { return {} as any },
     get VirtualInputHandler() { return {} as any },
     get OutputManager() { return {} as any },
-
+    get DialogManager() { return {} as any },
   }
 
   const mapManager = new MapManager(engine)

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -53,7 +53,8 @@ function createTestEngine() {
     get InputManager() { return {} as any },
     get ScriptRunner() { return {} as any },
     get VirtualInputHandler() { return {} as any },
-    get OutputManager() { return {} as any }
+    get OutputManager() { return {} as any },
+    get DialogManager() { return {} as any }
   }
 
   const pageManager = new PageManager(engine)


### PR DESCRIPTION
## Summary
- refactor GameEngine to use injected manager factory instead of direct instantiation
- wire concrete manager implementations in app bootstrap and adjust tests

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68913d5cdd108332afef83d691c27aa7