### PR TITLE
refactor: defer manager listener registration

### DIFF
--- a/src/engine/dialogManager.ts
+++ b/src/engine/dialogManager.ts
@@ -3,6 +3,7 @@ import type { IGameEngine } from './gameEngine'
 import { DIALOG_STARTED, START_DIALOG } from './messages'
 
 export interface IDialogManager {
+    initialize(): void
     cleanup(): void
 }
 
@@ -12,8 +13,11 @@ export class DialogManager implements IDialogManager {
 
     constructor(gameEngine: IGameEngine) {
         this.gameEngine = gameEngine
+    }
+
+    public initialize(): void {
         this.unregisterEventHandlers.push(
-            gameEngine.MessageBus.registerMessageListener(
+            this.gameEngine.MessageBus.registerMessageListener(
                 START_DIALOG,
                 async (message) => this.startDialog(message.payload as string)
             )

--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -150,6 +150,12 @@ export class GameEngine implements IGameEngine {
         this.outputManager = managerFactory.createOutputManager(this)
         this.dialogManager = managerFactory.createDialogManager(this)
         this.scriptRunner = managerFactory.createScriptRunner()
+        this.pageManager.initialize()
+        this.mapManager.initialize()
+        this.virtualInputHandler.initialize()
+        this.inputManager.initialize()
+        this.outputManager.initialize()
+        this.dialogManager.initialize()
         this.registerActionHandler(new PostMessageActionHandler())
         this.registerActionHandler(new ScriptActionHandler())
         this.registerConditionResolver(new ScriptConditionResolver())
@@ -175,6 +181,9 @@ export class GameEngine implements IGameEngine {
         this.pageManager.cleanup()
         this.mapManager.cleanup()
         this.virtualInputHandler.cleanup()
+        this.inputManager.cleanup()
+        this.outputManager.cleanup()
+        this.dialogManager.cleanup()
         this.cleanupHandlers()
     }
 

--- a/src/engine/inputManager.ts
+++ b/src/engine/inputManager.ts
@@ -21,6 +21,7 @@ export const nullMatrixInputItem: MatrixInputItem = {
 }
 
 export interface IInputManager {
+    initialize(): void
     cleanup(): void
     update(): void
     getInputMatrix(width: number, height: number): MatrixInputItem[][]
@@ -41,7 +42,15 @@ export class InputManager implements IInputManager {
 
     constructor(gameEngine: IGameEngine) {
         this.gameEngine = gameEngine
-        this.unregisterEventHandlers.push(gameEngine.MessageBus.registerMessageListener(VIRTUAL_INPUT_MESSAGE, (message) => this.onInput(message.payload as string)))
+    }
+
+    public initialize(): void {
+        this.unregisterEventHandlers.push(
+            this.gameEngine.MessageBus.registerMessageListener(
+                VIRTUAL_INPUT_MESSAGE,
+                (message) => this.onInput(message.payload as string)
+            )
+        )
     }
 
     public cleanup(): void {

--- a/src/engine/mapManager.ts
+++ b/src/engine/mapManager.ts
@@ -4,6 +4,7 @@ import { MAP_SWITCHED_MESSAGE, SWITCH_MAP_MESSAGE } from './messages'
 import type { GameMap } from '@loader/data/map'
 
 export interface IMapManager {
+    initialize(): void
     cleanup(): void
     switchMap(map: string): Promise<void>
 }
@@ -14,8 +15,11 @@ export class MapManager implements IMapManager {
 
     constructor(gameEngine: IGameEngine) {
         this.gameEngine = gameEngine
+    }
+
+    public initialize(): void {
         this.unregisterEventHandlers.push(
-            gameEngine.MessageBus.registerMessageListener(
+            this.gameEngine.MessageBus.registerMessageListener(
                 SWITCH_MAP_MESSAGE,
                 async (message) => this.switchMap(message.payload as string)
             )

--- a/src/engine/outputManager.ts
+++ b/src/engine/outputManager.ts
@@ -2,6 +2,7 @@ import type { IGameEngine } from './gameEngine'
 import { ADD_LINE_TO_OUTPUT_LOG, OUTPUT_LOG_LINE_ADDED } from './messages'
 
 export interface IOutputManager {
+    initialize(): void
     cleanup(): void
     getLastLines(maxCount: number): string[]
 }
@@ -14,8 +15,15 @@ export class OutputManager implements IOutputManager {
 
     constructor(gameEngine: IGameEngine) {
         this.gameEngine = gameEngine
-        this.unregisterEventHandlers.push(gameEngine.MessageBus.registerMessageListener(ADD_LINE_TO_OUTPUT_LOG, (message) => this.newLine(message.payload as string)))
+    }
 
+    public initialize(): void {
+        this.unregisterEventHandlers.push(
+            this.gameEngine.MessageBus.registerMessageListener(
+                ADD_LINE_TO_OUTPUT_LOG,
+                (message) => this.newLine(message.payload as string)
+            )
+        )
     }
 
     public cleanup(): void {

--- a/src/engine/pageManager.ts
+++ b/src/engine/pageManager.ts
@@ -3,6 +3,7 @@ import { type IGameEngine } from './gameEngine'
 import { PAGE_SWITCHED_MESSAGE, SWITCH_PAGE_MESSAGE } from './messages'
 
 export interface IPageManager {
+    initialize(): void
     switchPage(page: string): Promise<void>
     cleanup(): void
 }
@@ -13,8 +14,11 @@ export class PageManager implements IPageManager {
 
     constructor(gameEngine: IGameEngine) {
         this.gameEngine = gameEngine
+    }
+
+    public initialize(): void {
         this.unregisterEventHandlers.push(
-            gameEngine.MessageBus.registerMessageListener(
+            this.gameEngine.MessageBus.registerMessageListener(
                 SWITCH_PAGE_MESSAGE,
                 async (message) => this.switchPage(message.payload as string)
             )

--- a/src/engine/virtualInputHandler.ts
+++ b/src/engine/virtualInputHandler.ts
@@ -4,6 +4,7 @@ import { VIRTUAL_INPUT_MESSAGE } from './messages'
 import type { IGameEngine } from './gameEngine'
 
 export interface IVirtualInputHandler {
+    initialize(): void
     cleanup(): void
     load(): Promise<void>
     getVirtualInput(virtualInput: string): VirtualInput | null
@@ -19,6 +20,9 @@ export class VirtualInputHandler implements IVirtualInputHandler {
     constructor(gameEngine: IGameEngine) {
         this.gameEngine = gameEngine
         this.keydownEventHandler = (event: KeyboardEvent) => { this.onKeydownEvent(event.code, event.altKey, event.ctrlKey, event.shiftKey) }
+    }
+
+    public initialize(): void {
         if (typeof document !== 'undefined') {
             document.addEventListener('keydown', this.keydownEventHandler)
         }

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -6,12 +6,12 @@ import type { Action } from '@loader/data/action'
 function createEngine() {
   const loader = {} as unknown as ILoader
   const factory: IEngineManagerFactory = {
-    createPageManager: () => ({ switchPage: vi.fn(), cleanup: vi.fn() }) as any,
-    createMapManager: () => ({ switchMap: vi.fn(), cleanup: vi.fn() }) as any,
-    createVirtualInputHandler: () => ({ cleanup: vi.fn(), load: vi.fn(), getVirtualInput: vi.fn() }) as any,
-    createInputManager: () => ({ cleanup: vi.fn(), update: vi.fn(), getInputMatrix: vi.fn() }) as any,
-    createOutputManager: () => ({ cleanup: vi.fn(), getLastLines: vi.fn() }) as any,
-    createDialogManager: () => ({ cleanup: vi.fn() }) as any,
+    createPageManager: () => ({ initialize: vi.fn(), switchPage: vi.fn(), cleanup: vi.fn() }) as any,
+    createMapManager: () => ({ initialize: vi.fn(), switchMap: vi.fn(), cleanup: vi.fn() }) as any,
+    createVirtualInputHandler: () => ({ initialize: vi.fn(), cleanup: vi.fn(), load: vi.fn(), getVirtualInput: vi.fn() }) as any,
+    createInputManager: () => ({ initialize: vi.fn(), cleanup: vi.fn(), update: vi.fn(), getInputMatrix: vi.fn() }) as any,
+    createOutputManager: () => ({ initialize: vi.fn(), cleanup: vi.fn(), getLastLines: vi.fn() }) as any,
+    createDialogManager: () => ({ initialize: vi.fn(), cleanup: vi.fn() }) as any,
     createScriptRunner: () => ({ run: vi.fn() }) as any
   }
   const engine = new GameEngine(loader, factory)


### PR DESCRIPTION
## Summary
- defer message listener registration to new initialize methods for various engine managers
- explicitly initialize engine managers after instantiation and clean them up

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68914472ece483328b3ae27c0c3c804b