### PR TITLE
refactor: remove global game engine accessor

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
-import { GameEngineState, getGameEngine } from '@engine/gameEngine'
+import { GameEngineState, type IGameEngine } from '@engine/gameEngine'
 import { PAGE_SWITCHED_MESSAGE } from '@engine/messages'
 import type { Page as PageData } from '@loader/data/page'
 import { Page } from './controls/page'
 
-export const App: React.FC = (): React.JSX.Element => {
-  const engine = getGameEngine()
+export type AppProps = {
+  engine: IGameEngine
+}
+
+export const App: React.FC<AppProps> = ({ engine }): React.JSX.Element => {
   const engineState = useSyncExternalStore(engine.State.subscribe.bind(engine.State), () => engine.State.value)
   const [activePage, setActivePage] = useState<string | null>(engine.StateManager.state.data.activePage)
   useEffect(() => {
@@ -23,7 +26,7 @@ export const App: React.FC = (): React.JSX.Element => {
       return (<div>Loading game data ...</div>)
     case GameEngineState.running:
       return (
-        <Page page={page} />
+        <Page page={page} engine={engine} />
       )
   }
 }

--- a/src/app/components/gameMenu.tsx
+++ b/src/app/components/gameMenu.tsx
@@ -1,13 +1,13 @@
-import { getGameEngine } from '@engine/gameEngine'
+import type { IGameEngine } from '@engine/gameEngine'
 import type { Button } from '@loader/data/button'
 import type { GameMenuComponent } from '@loader/data/component'
 
 export type GameMenuProps = {
     component: GameMenuComponent
+    engine: IGameEngine
 }
 
-export const GameMenu: React.FC<GameMenuProps> = ({ component }): React.JSX.Element => {
-    const engine = getGameEngine()
+export const GameMenu: React.FC<GameMenuProps> = ({ component, engine }): React.JSX.Element => {
 
     const onButtonClick = (button: Button) => {
         engine.executeAction(button.action)

--- a/src/app/components/inputMatrix.tsx
+++ b/src/app/components/inputMatrix.tsx
@@ -1,5 +1,5 @@
 import type { CSSCustomProperties } from '@app/types'
-import { getGameEngine } from '@engine/gameEngine'
+import type { IGameEngine } from '@engine/gameEngine'
 import type { MatrixInputItem } from '@engine/inputManager'
 import { INPUTHANDLER_INPUTS_CHANGED, VIRTUAL_INPUT_MESSAGE } from '@engine/messages'
 import type { InputMatrixComponent } from '@loader/data/component'
@@ -7,10 +7,10 @@ import { useEffect, useState } from 'react'
 
 export type InputMatrixProps = {
     component: InputMatrixComponent
+    engine: IGameEngine
 }
 
-export const InputMatrix: React.FC<InputMatrixProps> = ({ component }): React.JSX.Element => {
-    const engine = getGameEngine()
+export const InputMatrix: React.FC<InputMatrixProps> = ({ component, engine }): React.JSX.Element => {
     const [inputMatrix, setInputMatrix] = useState(engine.InputManager.getInputMatrix(component.matrixSize.width, component.matrixSize.height))
     const style: CSSCustomProperties = {
         '--ge-input-matrix-width': component.matrixSize.width.toString(),

--- a/src/app/components/outputLog.tsx
+++ b/src/app/components/outputLog.tsx
@@ -1,15 +1,15 @@
 import { ScrollContainer } from '@app/controls/scrollContainer'
-import { getGameEngine } from '@engine/gameEngine'
+import type { IGameEngine } from '@engine/gameEngine'
 import { OUTPUT_LOG_LINE_ADDED } from '@engine/messages'
 import type { OutputComponent } from '@loader/data/component'
 import { useEffect, useState } from 'react'
 
 export type OutputLogProps = {
     component: OutputComponent
+    engine: IGameEngine
 }
 
-export const OutputLog: React.FC<OutputLogProps> = ({ component }): React.JSX.Element => {
-    const engine = getGameEngine()
+export const OutputLog: React.FC<OutputLogProps> = ({ component, engine }): React.JSX.Element => {
     const [outputLog, setOutputLog] = useState<string>(engine.OutputManager.getLastLines(component.logSize).join(' '))
 
     useEffect(() => {

--- a/src/app/components/squaresMap.tsx
+++ b/src/app/components/squaresMap.tsx
@@ -1,5 +1,5 @@
 import type { CSSCustomProperties } from '@app/types'
-import { getGameEngine } from '@engine/gameEngine'
+import type { IGameEngine } from '@engine/gameEngine'
 import { MAP_SWITCHED_MESSAGE, POSITION_CHANGED_MESSAGE } from '@engine/messages'
 import type { SquaresMapComponent } from '@loader/data/component'
 import type { GameMap } from '@loader/data/map'
@@ -8,6 +8,7 @@ import { Tile } from './tile'
 
 export type SquaresMapProps = {
     component: SquaresMapComponent
+    engine: IGameEngine
 }
 
 interface Position {
@@ -15,8 +16,7 @@ interface Position {
     y: number
 }
 
-export const SquaresMap: React.FC<SquaresMapProps> = ({ component }): React.JSX.Element => {
-    const engine = getGameEngine()
+export const SquaresMap: React.FC<SquaresMapProps> = ({ component, engine }): React.JSX.Element => {
     const [activeMap, setActiveMap] = useState<string | null>(engine.StateManager.state.data.location.mapName)
     const [pos, setPos] = useState<Position>(engine.StateManager.state.data.location.position)
 

--- a/src/app/controls/component.tsx
+++ b/src/app/controls/component.tsx
@@ -4,23 +4,25 @@ import { InputMatrix } from '@app/components/inputMatrix'
 import { OutputLog } from '@app/components/outputLog'
 import { SquaresMap } from '@app/components/squaresMap'
 import type { Component as ComponentData } from '@loader/data/component'
+import type { IGameEngine } from '@engine/gameEngine'
 
 export type ComponentProps = {
     component: ComponentData
+    engine: IGameEngine
 }
 
-export const Component:React.FC<ComponentProps> = ({ component }): React.JSX.Element => {
+export const Component:React.FC<ComponentProps> = ({ component, engine }): React.JSX.Element => {
     switch(component.type){
         case 'game-menu':
-            return <GameMenu component={component} />
+            return <GameMenu component={component} engine={engine} />
         case 'image':
             return <Image component={component} />
         case 'squares-map':
-            return <SquaresMap component={component} />
+            return <SquaresMap component={component} engine={engine} />
         case 'input-matrix':
-            return <InputMatrix component={component} />
+            return <InputMatrix component={component} engine={engine} />
         case 'output-log':
-            return <OutputLog component={component} />
+            return <OutputLog component={component} engine={engine} />
         default:
             return <div>TODO: {component.type}</div>
     }

--- a/src/app/controls/page.tsx
+++ b/src/app/controls/page.tsx
@@ -1,12 +1,15 @@
 import type { Page as PageData } from '@loader/data/page'
+import type { IGameEngine } from '@engine/gameEngine'
 import { Screen } from './screen'
+
 export type PageProps = {
     page: PageData | null
+    engine: IGameEngine
 }
 
-export const Page: React.FC<PageProps> = ({ page }): React.JSX.Element => {
+export const Page: React.FC<PageProps> = ({ page, engine }): React.JSX.Element => {
     if (page === null) return (<></>)
     return (
-        <Screen screen={page.screen} />
+        <Screen screen={page.screen} engine={engine} />
     )
 }

--- a/src/app/controls/screen.tsx
+++ b/src/app/controls/screen.tsx
@@ -1,14 +1,14 @@
 import type { CSSCustomProperties } from '@app/types'
 import type { Screen as ScreenData } from '@loader/data/page'
+import type { IGameEngine } from '@engine/gameEngine'
 import { Component } from './component'
-import { getGameEngine } from '@engine/gameEngine'
 
 export type ScreenProps = {
     screen: ScreenData
+    engine: IGameEngine
 }
 
-export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element => {
-    const engine = getGameEngine()
+export const Screen: React.FC<ScreenProps> = ({ screen, engine }): React.JSX.Element => {
     switch (screen.type) {
         case 'grid': {
             const style: CSSCustomProperties = {
@@ -28,7 +28,7 @@ export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element => 
                             }
                             return (
                                 <div className='grid-component' style={componentStyle} key={key}>
-                                    <Component component={item.component} />
+                                    <Component component={item.component} engine={engine} />
                                 </div>
                             )
                         } else return null

--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -26,17 +26,6 @@ import { ScriptActionHandler } from './actions/scriptActionHandler'
 import type { IConditionResolver } from './conditions/conditionResolver'
 import { ScriptConditionResolver } from './conditions/scriptConditionResolver'
 
-let gameEngine: GameEngine | null = null
-function setGameEngine(engine: GameEngine): void {
-    gameEngine = engine
-}
-export function getGameEngine(): IGameEngine {
-    if (gameEngine === null) {
-        fatalError('Game engine is not initialized')
-    }
-    return gameEngine
-}
-
 export const GameEngineState = {
     init: 0,
     loading: 1,
@@ -142,7 +131,6 @@ export class GameEngine implements IGameEngine {
             }
         )
         this.translationService = new TranslationService()
-        setGameEngine(this)
         this.pageManager = managerFactory.createPageManager(this)
         this.mapManager = managerFactory.createMapManager(this)
         this.virtualInputHandler = managerFactory.createVirtualInputHandler(this)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,6 +43,6 @@ await engine.start()
 
 const root = document.getElementById('app')
 if (root) {
-  createRoot(root).render(<App />)
+  createRoot(root).render(<App engine={engine} />)
 }
 

--- a/test/app/screen.test.tsx
+++ b/test/app/screen.test.tsx
@@ -1,10 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { Screen } from '@app/controls/screen'
 import type { Screen as ScreenData } from '@loader/data/page'
-
-vi.mock('@engine/gameEngine', () => ({
-  getGameEngine: () => ({ resolveCondition: () => true }),
-}))
+import type { IGameEngine } from '@engine/gameEngine'
 
 describe('Screen', () => {
   it('applies grid position variables to components', () => {
@@ -20,7 +17,8 @@ describe('Screen', () => {
       ],
     }
 
-    const element = Screen({ screen: screenData }) as React.ReactElement<Record<string, unknown>>
+    const engine = { resolveCondition: () => true } as unknown as IGameEngine
+    const element = Screen({ screen: screenData, engine }) as React.ReactElement<Record<string, unknown>>
     const child = (element.props.children as React.ReactElement<Record<string, unknown>>[])[0]
     const style = child.props.style as Record<string, string>
 


### PR DESCRIPTION
## Summary
- remove game engine singleton accessor and rely on injected references
- pass `IGameEngine` through React components instead of calling a global getter
- adjust tests to provide engine stubs explicitly

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a60030b08332abf3062d6e845a5f