### PR TITLE
Fix state manager initialization order

### DIFF
--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -107,6 +107,7 @@ export class GameEngine implements IGameEngine {
             }
         )
         this.translationService = managerFactory.createTranslationService()
+        this.initStateManager()
         this.pageManager = managerFactory.createPageManager(this)
         this.mapManager = managerFactory.createMapManager(this)
         this.virtualInputHandler = managerFactory.createVirtualInputHandler(this)
@@ -130,7 +131,6 @@ export class GameEngine implements IGameEngine {
         await this.loader.reset()
         await this.registerGameHandlers()
         await this.virtualInputHandler.load()
-        this.initStateManager()
         const language = (this.currentLanguage ?? this.stateManager?.state.language) ?? fatalError('No language set!')
         this.currentLanguage = language
         this.translationService.setLanguage(await this.loader.loadLanguage(language))

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -4,7 +4,13 @@ import type { ILoader } from '@loader/loader'
 import type { Action } from '@loader/data/action'
 
 function createEngine() {
-  const loader = {} as unknown as ILoader
+  const loader = {
+    Game: {
+      initialData: {
+        language: 'en'
+      }
+    }
+  } as unknown as ILoader
   const factory: IEngineManagerFactory = {
     createPageManager: () => ({ initialize: vi.fn(), switchPage: vi.fn(), cleanup: vi.fn() }) as any,
     createMapManager: () => ({ initialize: vi.fn(), switchMap: vi.fn(), cleanup: vi.fn() }) as any,


### PR DESCRIPTION
## Summary
- initialize the state manager before creating page, map, input, and other managers
- remove redundant state manager init in engine start
- update GameEngine test with loader stub containing initial data

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6891dbc7b79c833294ab0326d5d16271