### PR TITLE
refactor: inject virtual input handler services

### DIFF
--- a/src/engine/virtualInputHandlerService.ts
+++ b/src/engine/virtualInputHandlerService.ts
@@ -1,0 +1,10 @@
+import type { IGameEngine } from './gameEngine'
+import { VirtualInputHandler, type IVirtualInputHandler, type VirtualInputHandlerServices } from './virtualInputHandler'
+
+export function createVirtualInputHandler(engine: IGameEngine): IVirtualInputHandler {
+    const services: VirtualInputHandlerServices = {
+        loader: engine.Loader,
+        messageBus: engine.MessageBus
+    }
+    return new VirtualInputHandler(services)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { Loader, type ILoader } from '@loader/loader'
 import { GameEngine, type IGameEngine, type IEngineManagerFactory } from '@engine/gameEngine'
 import { createPageManager } from '@engine/pageManagerService'
 import { createMapManager } from '@engine/mapManagerService'
-import { VirtualInputHandler } from '@engine/virtualInputHandler'
+import { createVirtualInputHandler } from '@engine/virtualInputHandlerService'
 import { createInputManager } from '@engine/inputManagerService'
 import { createOutputManager } from '@engine/outputManagerService'
 import { createDialogManager } from '@engine/dialogManagerService'
@@ -32,7 +32,7 @@ loader.Styling.forEach(css => {
 const factory: IEngineManagerFactory = {
   createPageManager: (engine) => createPageManager(engine),
   createMapManager: (engine) => createMapManager(engine),
-  createVirtualInputHandler: (engine) => new VirtualInputHandler(engine),
+  createVirtualInputHandler: (engine) => createVirtualInputHandler(engine),
   createInputManager: (engine) => createInputManager(engine),
   createOutputManager: (engine) => createOutputManager(engine),
   createDialogManager: (engine) => createDialogManager(engine),


### PR DESCRIPTION
## Summary
- Refactor VirtualInputHandler to depend on `VirtualInputHandlerServices` instead of the whole engine
- Add `createVirtualInputHandler` factory to assemble services from `GameEngine`
- Update engine bootstrap to use the new factory

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6891fc344a908332a772a104550e6ad1