### PR TITLE
feat(engine): inject action and condition handlers

### DIFF
--- a/src/engine/gameEngine.ts
+++ b/src/engine/gameEngine.ts
@@ -18,10 +18,7 @@ import type { IOutputManager } from './outputManager'
 import type { IDialogManager } from './dialogManager'
 import type { ContextData } from './context'
 import type { IActionHandler } from './actions/actionHandler'
-import { PostMessageActionHandler } from './actions/postMessageActionHandler'
-import { ScriptActionHandler } from './actions/scriptActionHandler'
 import type { IConditionResolver } from './conditions/conditionResolver'
-import { ScriptConditionResolver } from './conditions/scriptConditionResolver'
 
 export const GameEngineState = {
     init: 0,
@@ -65,6 +62,11 @@ export interface IEngineManagerFactory {
     createScriptRunner(): IScriptRunner
 }
 
+export interface GameEngineOptions {
+    actionHandlers?: IActionHandler[]
+    conditionResolvers?: IConditionResolver[]
+}
+
 export class GameEngine implements IGameEngine {
     private loader: ILoader
     private messageBus: MessageBus
@@ -86,7 +88,7 @@ export class GameEngine implements IGameEngine {
     private actionHandlers = new Map<string, IActionHandler>()
     private conditionResolvers = new Map<string, IConditionResolver>()
 
-    constructor(loader: ILoader, managerFactory: IEngineManagerFactory) {
+    constructor(loader: ILoader, managerFactory: IEngineManagerFactory, options: GameEngineOptions = {}) {
         this.loader = loader
         this.messageBus = new MessageBus(() => this.handleOnQueueEmpty())
         this.initializeMessageListeners()
@@ -118,9 +120,8 @@ export class GameEngine implements IGameEngine {
         this.inputManager.initialize()
         this.outputManager.initialize()
         this.dialogManager.initialize()
-        this.registerActionHandler(new PostMessageActionHandler())
-        this.registerActionHandler(new ScriptActionHandler())
-        this.registerConditionResolver(new ScriptConditionResolver())
+        options.actionHandlers?.forEach(h => this.registerActionHandler(h))
+        options.conditionResolvers?.forEach(r => this.registerConditionResolver(r))
     }
 
     public async start(): Promise<void> {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { createRoot } from 'react-dom/client'
 import { logDebug } from '@utils/logMessage'
 import { Loader, type ILoader } from '@loader/loader'
 import { GameEngine, type IGameEngine, type IEngineManagerFactory } from '@engine/gameEngine'
+import { PostMessageActionHandler } from '@engine/actions/postMessageActionHandler'
+import { ScriptActionHandler } from '@engine/actions/scriptActionHandler'
+import { ScriptConditionResolver } from '@engine/conditions/scriptConditionResolver'
 import { createPageManager } from '@engine/pageManagerService'
 import { createMapManager } from '@engine/mapManagerService'
 import { createVirtualInputHandler } from '@engine/virtualInputHandlerService'
@@ -40,7 +43,10 @@ const factory: IEngineManagerFactory = {
   createScriptRunner: () => createScriptRunner()
 }
 
-const engine: IGameEngine = new GameEngine(loader, factory)
+const engine: IGameEngine = new GameEngine(loader, factory, {
+  actionHandlers: [new PostMessageActionHandler(), new ScriptActionHandler()],
+  conditionResolvers: [new ScriptConditionResolver()]
+})
 await engine.start()
 
 const root = document.getElementById('app')

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { GameEngine, type IEngineManagerFactory } from '@engine/gameEngine'
 import type { ILoader } from '@loader/loader'
 import type { Action } from '@loader/data/action'
+import { PostMessageActionHandler } from '@engine/actions/postMessageActionHandler'
 
 function createEngine() {
   const loader = {
@@ -21,7 +22,9 @@ function createEngine() {
     createTranslationService: () => ({ translate: vi.fn(), setLanguage: vi.fn() }) as any,
     createScriptRunner: () => ({ run: vi.fn() }) as any
   }
-  const engine = new GameEngine(loader, factory)
+  const engine = new GameEngine(loader, factory, {
+    actionHandlers: [new PostMessageActionHandler()]
+  })
   const bus = {
     postMessage: vi.fn(),
     registerMessageListener: vi.fn(),


### PR DESCRIPTION
## Summary
- inject arrays of `IActionHandler` and `IConditionResolver` via `GameEngine` constructor
- provide default handlers in app bootstrap
- adjust unit test for new `GameEngine` constructor

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6892089752d08332a97a1850581a0617