### PR TITLE
refactor: modularize input management

### DIFF
--- a/src/engine/inputManager.ts
+++ b/src/engine/inputManager.ts
@@ -1,30 +1,11 @@
-import { create2DArray } from '@utils/array'
 import type { IMessageBus } from '@utils/messageBus'
-import type { ITranslationService } from './translationService'
-import type { IVirtualInputHandler } from './virtualInputHandler'
-import type { IStateManager } from './stateManager'
-import type { ContextData } from './context'
-import { INPUTHANDLER_INPUTS_CHANGED, VIRTUAL_INPUT_MESSAGE } from './messages'
-import type { Input } from '@loader/data/inputs'
-import { hasMapChanged, updateMap } from '@utils/map'
-import type { Condition } from '@loader/data/condition'
+import { VIRTUAL_INPUT_MESSAGE } from './messages'
 import type { Action } from '@loader/data/action'
+import { InputSourceTracker } from './inputSourceTracker'
+import { InputMatrixBuilder, type MatrixInputItem } from './inputMatrixBuilder'
 
-export type MatrixInputItem = {
-    enabled: boolean
-    label: string
-    description: string
-    virtualInput: string
-    character: string
-}
-
-export const nullMatrixInputItem: MatrixInputItem = {
-    enabled: false,
-    label: '',
-    description: '',
-    virtualInput: '',
-    character: ''
-}
+export type { MatrixInputItem } from './inputMatrixBuilder'
+export { nullMatrixInputItem } from './inputMatrixBuilder'
 
 export interface IInputManager {
     initialize(): void
@@ -33,27 +14,16 @@ export interface IInputManager {
     getInputMatrix(width: number, height: number): MatrixInputItem[][]
 }
 
-type InputItem = {
-    input: Input
-    enabled: boolean
-    visible: boolean
-}
-
 export type InputManagerServices = {
     messageBus: IMessageBus
-    translationService: ITranslationService
-    virtualInputHandler: IVirtualInputHandler
-    stateManager: IStateManager<ContextData>
-    resolveCondition: (condition: Condition | null) => boolean
+    inputSourceTracker: InputSourceTracker
+    inputMatrixBuilder: InputMatrixBuilder
     executeAction: (action: Action) => void
 }
 
 export class InputManager implements IInputManager {
     private unregisterEventHandlers: (() => void)[] = []
     private services: InputManagerServices
-    private currentPage: string | null = null
-    private inputs: Map<string, InputItem> = new Map()
-    private previousInputs: Map<string, InputItem> = new Map()
 
     constructor(services: InputManagerServices) {
         this.services = services
@@ -74,93 +44,16 @@ export class InputManager implements IInputManager {
     }
 
     public update(): void {
-        if (!this.checkSources()) {
-            this.recalculateInputConditions()
-        }
+        this.services.inputSourceTracker.update()
     }
 
     public getInputMatrix(width: number, height: number): MatrixInputItem[][] {
-        const matrix: MatrixInputItem[][] = create2DArray<MatrixInputItem>(height, width, nullMatrixInputItem)
-        const itemsToProcess: InputItem[] = Array.from(this.inputs.values()).filter(item => item.visible)
-
-        for (let y = 0; y < height; y++) {
-            for (let x = 0; x < width; x++) {
-                let found = false
-                for (let index = itemsToProcess.length-1; index >= 0 && !found; index--) {
-                    const inputItem = itemsToProcess[index]
-                    if (inputItem.input.preferredCol === x && inputItem.input.preferredRow === y){
-                        found = true
-                        matrix[y][x] = this.getMatrixInputItem(inputItem)
-                        itemsToProcess.splice(index, 1)
-                    }
-                }
-                if (!found) {
-                    matrix[y][x] = nullMatrixInputItem
-                }
-            }
-        }
-
-        for (let y=height - 1; y >= 0 && itemsToProcess.length > 0; y--) {
-            for (let x=width -1 ; x >=0 && itemsToProcess.length > 0; x--){
-                if (matrix[y][x] === nullMatrixInputItem) {
-                    matrix[y][x] = this.getMatrixInputItem(itemsToProcess.shift()!)
-                }
-            }
-        }
-
-        return matrix
-    }
-
-    private getMatrixInputItem(inputItem: InputItem): MatrixInputItem {
-        const matrixItem: MatrixInputItem = {
-            enabled: inputItem.enabled,
-            label: this.services.translationService.translate(inputItem.input.label),
-            description: this.services.translationService.translate(inputItem.input.description),
-            virtualInput: inputItem.input.virtualInput,
-            character: this.services.virtualInputHandler.getVirtualInput(inputItem.input.virtualInput)?.label ?? ''
-        }
-        return matrixItem
-    }
-
-    private recalculateInputConditions(): void {
-        this.inputs.forEach((inputItem) => {
-            const input = inputItem.input
-            inputItem.enabled = this.services.resolveCondition(input.enabled ?? null)
-            inputItem.visible = this.services.resolveCondition(input.visible ?? null)
-        })
-
-        if (hasMapChanged(this.previousInputs, this.inputs,
-            (a,b) => a.input.virtualInput === b.input.virtualInput && a.enabled === b.enabled && a.visible == b.visible)) {
-                updateMap(this.previousInputs, this.inputs, item => ({ ...item }))
-                this.services.messageBus.postMessage({
-                    message: INPUTHANDLER_INPUTS_CHANGED,
-                    payload: {}
-                })
-            }
-    }
-
-    private checkSources(): boolean {
-        if (this.currentPage === this.services.stateManager.state.data.activePage) {
-            return false
-        }
-        this.inputs.clear()
-        this.currentPage = this.services.stateManager.state.data.activePage
-        if (this.currentPage === null) {
-            return false
-        }
-        const page = this.services.stateManager.state.pages[this.currentPage]
-        page.inputs.forEach(input => {
-            this.inputs.set(input.virtualInput, {
-                input,
-                enabled: this.services.resolveCondition(input.enabled ?? null),
-                visible: this.services.resolveCondition(input.visible ?? null)
-            })
-        })
-        return true
+        const inputs = this.services.inputSourceTracker.getVisibleInputs()
+        return this.services.inputMatrixBuilder.build(width, height, inputs)
     }
 
     private onInput(input: string): void {
-        const inputItem = this.inputs.get(input)
+        const inputItem = this.services.inputSourceTracker.getInput(input)
         if (inputItem && inputItem.enabled && inputItem.input.action) {
             this.services.executeAction(inputItem.input.action)
         }

--- a/src/engine/inputManagerService.ts
+++ b/src/engine/inputManagerService.ts
@@ -1,14 +1,27 @@
 import type { IGameEngine } from './gameEngine'
 import { InputManager, type IInputManager, type InputManagerServices } from './inputManager'
+import { InputSourceTracker } from './inputSourceTracker'
+import { InputMatrixBuilder } from './inputMatrixBuilder'
+import type { Action } from '@loader/data/action'
 
 export function createInputManager(engine: IGameEngine): IInputManager {
+    const inputSourceTracker = new InputSourceTracker({
+        messageBus: engine.MessageBus,
+        stateManager: engine.StateManager,
+        resolveCondition: (condition) => engine.resolveCondition(condition)
+    })
+
+    const inputMatrixBuilder = new InputMatrixBuilder({
+        translationService: engine.TranslationService,
+        virtualInputHandler: engine.VirtualInputHandler
+    })
+
     const services: InputManagerServices = {
         messageBus: engine.MessageBus,
-        translationService: engine.TranslationService,
-        virtualInputHandler: engine.VirtualInputHandler,
-        stateManager: engine.StateManager,
-        resolveCondition: (condition) => engine.resolveCondition(condition),
-        executeAction: (action) => engine.executeAction(action)
+        inputSourceTracker,
+        inputMatrixBuilder,
+        executeAction: (action: Action) => engine.executeAction(action)
     }
     return new InputManager(services)
 }
+

--- a/src/engine/inputMatrixBuilder.ts
+++ b/src/engine/inputMatrixBuilder.ts
@@ -1,0 +1,76 @@
+import { create2DArray } from '@utils/array'
+import type { ITranslationService } from './translationService'
+import type { IVirtualInputHandler } from './virtualInputHandler'
+import type { InputItem } from './inputSourceTracker'
+
+export type MatrixInputItem = {
+    enabled: boolean
+    label: string
+    description: string
+    virtualInput: string
+    character: string
+}
+
+export const nullMatrixInputItem: MatrixInputItem = {
+    enabled: false,
+    label: '',
+    description: '',
+    virtualInput: '',
+    character: ''
+}
+
+export type InputMatrixBuilderServices = {
+    translationService: ITranslationService
+    virtualInputHandler: IVirtualInputHandler
+}
+
+export class InputMatrixBuilder {
+    private services: InputMatrixBuilderServices
+
+    constructor(services: InputMatrixBuilderServices) {
+        this.services = services
+    }
+
+    public build(width: number, height: number, inputs: InputItem[]): MatrixInputItem[][] {
+        const matrix: MatrixInputItem[][] = create2DArray<MatrixInputItem>(height, width, nullMatrixInputItem)
+        const itemsToProcess: InputItem[] = [...inputs]
+
+        for (let y = 0; y < height; y++) {
+            for (let x = 0; x < width; x++) {
+                let found = false
+                for (let index = itemsToProcess.length - 1; index >= 0 && !found; index--) {
+                    const inputItem = itemsToProcess[index]
+                    if (inputItem.input.preferredCol === x && inputItem.input.preferredRow === y) {
+                        found = true
+                        matrix[y][x] = this.getMatrixInputItem(inputItem)
+                        itemsToProcess.splice(index, 1)
+                    }
+                }
+                if (!found) {
+                    matrix[y][x] = nullMatrixInputItem
+                }
+            }
+        }
+
+        for (let y = height - 1; y >= 0 && itemsToProcess.length > 0; y--) {
+            for (let x = width - 1; x >= 0 && itemsToProcess.length > 0; x--) {
+                if (matrix[y][x] === nullMatrixInputItem) {
+                    matrix[y][x] = this.getMatrixInputItem(itemsToProcess.shift()!)
+                }
+            }
+        }
+
+        return matrix
+    }
+
+    private getMatrixInputItem(inputItem: InputItem): MatrixInputItem {
+        return {
+            enabled: inputItem.enabled,
+            label: this.services.translationService.translate(inputItem.input.label),
+            description: this.services.translationService.translate(inputItem.input.description),
+            virtualInput: inputItem.input.virtualInput,
+            character: this.services.virtualInputHandler.getVirtualInput(inputItem.input.virtualInput)?.label ?? ''
+        }
+    }
+}
+

--- a/src/engine/inputSourceTracker.ts
+++ b/src/engine/inputSourceTracker.ts
@@ -1,0 +1,86 @@
+import type { IMessageBus } from '@utils/messageBus'
+import type { IStateManager } from './stateManager'
+import type { ContextData } from './context'
+import type { Input } from '@loader/data/inputs'
+import type { Condition } from '@loader/data/condition'
+import { hasMapChanged, updateMap } from '@utils/map'
+import { INPUTHANDLER_INPUTS_CHANGED } from './messages'
+
+export type InputItem = {
+    input: Input
+    enabled: boolean
+    visible: boolean
+}
+
+export type InputSourceTrackerServices = {
+    messageBus: IMessageBus
+    stateManager: IStateManager<ContextData>
+    resolveCondition: (condition: Condition | null) => boolean
+}
+
+export class InputSourceTracker {
+    private services: InputSourceTrackerServices
+    private currentPage: string | null = null
+    private inputs: Map<string, InputItem> = new Map()
+    private previousInputs: Map<string, InputItem> = new Map()
+
+    constructor(services: InputSourceTrackerServices) {
+        this.services = services
+    }
+
+    public update(): void {
+        if (!this.loadInputs()) {
+            this.recalculateInputConditions()
+        }
+    }
+
+    public getInput(virtualInput: string): InputItem | undefined {
+        return this.inputs.get(virtualInput)
+    }
+
+    public getVisibleInputs(): InputItem[] {
+        return Array.from(this.inputs.values()).filter(item => item.visible)
+    }
+
+    private loadInputs(): boolean {
+        const activePage = this.services.stateManager.state.data.activePage
+        if (this.currentPage === activePage) {
+            return false
+        }
+        this.inputs.clear()
+        this.currentPage = activePage
+        if (activePage === null) {
+            return false
+        }
+        const page = this.services.stateManager.state.pages[activePage]
+        page.inputs.forEach(input => {
+            this.inputs.set(input.virtualInput, {
+                input,
+                enabled: this.services.resolveCondition(input.enabled ?? null),
+                visible: this.services.resolveCondition(input.visible ?? null)
+            })
+        })
+        return true
+    }
+
+    private recalculateInputConditions(): void {
+        this.inputs.forEach(inputItem => {
+            const input = inputItem.input
+            inputItem.enabled = this.services.resolveCondition(input.enabled ?? null)
+            inputItem.visible = this.services.resolveCondition(input.visible ?? null)
+        })
+
+        if (hasMapChanged(
+            this.previousInputs,
+            this.inputs,
+            (a, b) => a.input.virtualInput === b.input.virtualInput && a.enabled === b.enabled && a.visible === b.visible
+        )) {
+            updateMap(this.previousInputs, this.inputs, item => ({ ...item }))
+            this.services.messageBus.postMessage({
+                message: INPUTHANDLER_INPUTS_CHANGED,
+                payload: {}
+            })
+        }
+    }
+}
+

--- a/test/engine/inputManager.test.ts
+++ b/test/engine/inputManager.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { InputManager, type InputManagerServices } from '@engine/inputManager'
+import { InputSourceTracker } from '@engine/inputSourceTracker'
+import { InputMatrixBuilder } from '@engine/inputMatrixBuilder'
 import { VIRTUAL_INPUT_MESSAGE } from '@engine/messages'
 import type { ContextData } from '@engine/context'
 import type { Input } from '@loader/data/inputs'
@@ -48,12 +50,21 @@ function createInputManager(actionFn = vi.fn()) {
   }
   const stateManager = { state } as any
 
+  const inputSourceTracker = new InputSourceTracker({
+    messageBus: messageBus as any,
+    stateManager,
+    resolveCondition: () => true
+  })
+
+  const inputMatrixBuilder = new InputMatrixBuilder({
+    translationService: translationService as any,
+    virtualInputHandler: virtualInputHandler as any
+  })
+
   const services: InputManagerServices = {
     messageBus: messageBus as any,
-    translationService: translationService as any,
-    virtualInputHandler: virtualInputHandler as any,
-    stateManager,
-    resolveCondition: () => true,
+    inputSourceTracker,
+    inputMatrixBuilder,
     executeAction: actionFn
   }
 


### PR DESCRIPTION
## Summary
- extract InputSourceTracker to handle page input state and notifications
- move matrix construction into InputMatrixBuilder
- simplify InputManager to coordinate tracker/builder and execute actions
- update factory and tests for new modules

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68920f7bf5848332aabbfd108fdef102