### PR TITLE
Inject state manager into manager factories

### DIFF
--- a/src/engine/gameEngineInitializer.ts
+++ b/src/engine/gameEngineInitializer.ts
@@ -17,10 +17,10 @@ import { TurnScheduler } from './turnScheduler'
 import { GameEngine, type IGameEngine } from './gameEngine'
 
 export interface IEngineManagerFactory {
-    createPageManager(engine: IGameEngine): IPageManager
-    createMapManager(engine: IGameEngine): IMapManager
+    createPageManager(engine: IGameEngine, stateManager: IStateManager<ContextData>): IPageManager
+    createMapManager(engine: IGameEngine, stateManager: IStateManager<ContextData>): IMapManager
     createVirtualInputHandler(engine: IGameEngine): IVirtualInputHandler
-    createInputManager(engine: IGameEngine): IInputManager
+    createInputManager(engine: IGameEngine, stateManager: IStateManager<ContextData>): IInputManager
     createOutputManager(engine: IGameEngine): IOutputManager
     createDialogManager(engine: IGameEngine): IDialogManager
     createTranslationService(): ITranslationService
@@ -60,10 +60,10 @@ export class GameEngineInitializer {
         const translationService = factory.createTranslationService()
         const scriptRunner = factory.createScriptRunner()
 
-        const pageManager = factory.createPageManager(engine)
-        const mapManager = factory.createMapManager(engine)
+        const pageManager = factory.createPageManager(engine, stateManager)
+        const mapManager = factory.createMapManager(engine, stateManager)
         const virtualInputHandler = factory.createVirtualInputHandler(engine)
-        const inputManager = factory.createInputManager(engine)
+        const inputManager = factory.createInputManager(engine, stateManager)
         const outputManager = factory.createOutputManager(engine)
         const dialogManager = factory.createDialogManager(engine)
 

--- a/src/engine/inputManagerService.ts
+++ b/src/engine/inputManagerService.ts
@@ -3,11 +3,16 @@ import { InputManager, type IInputManager, type InputManagerServices } from './i
 import { InputSourceTracker } from './inputSourceTracker'
 import { InputMatrixBuilder } from './inputMatrixBuilder'
 import type { Action } from '@loader/data/action'
+import type { IStateManager } from './stateManager'
+import type { ContextData } from './context'
 
-export function createInputManager(engine: IGameEngine): IInputManager {
+export function createInputManager(
+    engine: IGameEngine,
+    stateManager: IStateManager<ContextData>
+): IInputManager {
     const inputSourceTracker = new InputSourceTracker({
         messageBus: engine.MessageBus,
-        stateManager: engine.StateManager,
+        stateManager,
         resolveCondition: (condition) => engine.resolveCondition(condition)
     })
 

--- a/src/engine/mapManagerService.ts
+++ b/src/engine/mapManagerService.ts
@@ -1,11 +1,16 @@
 import type { IGameEngine } from './gameEngine'
 import { MapManager, type IMapManager, type MapManagerServices } from './mapManager'
+import type { IStateManager } from './stateManager'
+import type { ContextData } from './context'
 
-export function createMapManager(engine: IGameEngine): IMapManager {
+export function createMapManager(
+    engine: IGameEngine,
+    stateManager: IStateManager<ContextData>
+): IMapManager {
     const services: MapManagerServices = {
         loader: engine.Loader,
         messageBus: engine.MessageBus,
-        stateManager: engine.StateManager,
+        stateManager,
         setIsLoading: () => engine.setIsLoading(),
         setIsRunning: () => engine.setIsRunning()
     }

--- a/src/engine/pageManagerService.ts
+++ b/src/engine/pageManagerService.ts
@@ -1,11 +1,16 @@
 import type { IGameEngine } from './gameEngine'
 import { PageManager, type IPageManager, type PageManagerServices } from './pageManager'
+import type { IStateManager } from './stateManager'
+import type { ContextData } from './context'
 
-export function createPageManager(engine: IGameEngine): IPageManager {
+export function createPageManager(
+    engine: IGameEngine,
+    stateManager: IStateManager<ContextData>
+): IPageManager {
     const services: PageManagerServices = {
         loader: engine.Loader,
         messageBus: engine.MessageBus,
-        stateManager: engine.StateManager,
+        stateManager,
         setIsLoading: () => engine.setIsLoading(),
         setIsRunning: () => engine.setIsRunning()
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,10 +34,10 @@ loader.Styling.forEach(css => {
 })
 
 const factory: IEngineManagerFactory = {
-  createPageManager: (engine) => createPageManager(engine),
-  createMapManager: (engine) => createMapManager(engine),
+  createPageManager: (engine, stateManager) => createPageManager(engine, stateManager),
+  createMapManager: (engine, stateManager) => createMapManager(engine, stateManager),
   createVirtualInputHandler: (engine) => createVirtualInputHandler(engine),
-  createInputManager: (engine) => createInputManager(engine),
+  createInputManager: (engine, stateManager) => createInputManager(engine, stateManager),
   createOutputManager: (engine) => createOutputManager(engine),
   createDialogManager: (engine) => createDialogManager(engine),
   createTranslationService: () => createTranslationService(),

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -13,10 +13,22 @@ function createEngine() {
     }
   } as unknown as ILoader
   const factory: IEngineManagerFactory = {
-    createPageManager: () => ({ initialize: vi.fn(), switchPage: vi.fn(), cleanup: vi.fn() }) as any,
-    createMapManager: () => ({ initialize: vi.fn(), switchMap: vi.fn(), cleanup: vi.fn() }) as any,
+    createPageManager: (engine, stateManager) => {
+      void engine
+      void stateManager
+      return { initialize: vi.fn(), switchPage: vi.fn(), cleanup: vi.fn() } as any
+    },
+    createMapManager: (engine, stateManager) => {
+      void engine
+      void stateManager
+      return { initialize: vi.fn(), switchMap: vi.fn(), cleanup: vi.fn() } as any
+    },
     createVirtualInputHandler: () => ({ initialize: vi.fn(), cleanup: vi.fn(), load: vi.fn(), getVirtualInput: vi.fn() }) as any,
-    createInputManager: () => ({ initialize: vi.fn(), cleanup: vi.fn(), update: vi.fn(), getInputMatrix: vi.fn() }) as any,
+    createInputManager: (engine, stateManager) => {
+      void engine
+      void stateManager
+      return { initialize: vi.fn(), cleanup: vi.fn(), update: vi.fn(), getInputMatrix: vi.fn() } as any
+    },
     createOutputManager: () => ({ initialize: vi.fn(), cleanup: vi.fn(), getLastLines: vi.fn() }) as any,
     createDialogManager: () => ({ initialize: vi.fn(), cleanup: vi.fn() }) as any,
     createTranslationService: () => ({ translate: vi.fn(), setLanguage: vi.fn() }) as any,


### PR DESCRIPTION
## Summary
- Pass the state manager explicitly to page, map, and input manager factories
- Update engine initializer and application setup to provide the state manager when creating managers
- Adjust tests for new factory signatures

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689218401e3c8332b10ff69fcc216303