### PR TITLE
fix: pass message bus to page manager

### DIFF
--- a/src/engine/gameEngineInitializer.ts
+++ b/src/engine/gameEngineInitializer.ts
@@ -17,7 +17,7 @@ import { TurnScheduler } from './turnScheduler'
 import { GameEngine, type IGameEngine } from './gameEngine'
 
 export interface IEngineManagerFactory {
-    createPageManager(engine: IGameEngine, stateManager: IStateManager<ContextData>): IPageManager
+    createPageManager(engine: IGameEngine, messageBus: MessageBus, stateManager: IStateManager<ContextData>): IPageManager
     createMapManager(engine: IGameEngine, stateManager: IStateManager<ContextData>): IMapManager
     createVirtualInputHandler(engine: IGameEngine): IVirtualInputHandler
     createInputManager(engine: IGameEngine, stateManager: IStateManager<ContextData>): IInputManager
@@ -60,7 +60,7 @@ export class GameEngineInitializer {
         const translationService = factory.createTranslationService()
         const scriptRunner = factory.createScriptRunner()
 
-        const pageManager = factory.createPageManager(engine, stateManager)
+        const pageManager = factory.createPageManager(engine, messageBus, stateManager)
         const mapManager = factory.createMapManager(engine, stateManager)
         const virtualInputHandler = factory.createVirtualInputHandler(engine)
         const inputManager = factory.createInputManager(engine, stateManager)

--- a/src/engine/pageManagerService.ts
+++ b/src/engine/pageManagerService.ts
@@ -2,14 +2,16 @@ import type { IGameEngine } from './gameEngine'
 import { PageManager, type IPageManager, type PageManagerServices } from './pageManager'
 import type { IStateManager } from './stateManager'
 import type { ContextData } from './context'
+import type { IMessageBus } from '@utils/messageBus'
 
 export function createPageManager(
     engine: IGameEngine,
+    messageBus: IMessageBus,
     stateManager: IStateManager<ContextData>
 ): IPageManager {
     const services: PageManagerServices = {
         loader: engine.Loader,
-        messageBus: engine.MessageBus,
+        messageBus,
         stateManager,
         setIsLoading: () => engine.setIsLoading(),
         setIsRunning: () => engine.setIsRunning()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,7 +34,7 @@ loader.Styling.forEach(css => {
 })
 
 const factory: IEngineManagerFactory = {
-  createPageManager: (engine, stateManager) => createPageManager(engine, stateManager),
+  createPageManager: (engine, messageBus, stateManager) => createPageManager(engine, messageBus, stateManager),
   createMapManager: (engine, stateManager) => createMapManager(engine, stateManager),
   createVirtualInputHandler: (engine) => createVirtualInputHandler(engine),
   createInputManager: (engine, stateManager) => createInputManager(engine, stateManager),

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -13,8 +13,9 @@ function createEngine() {
     }
   } as unknown as ILoader
   const factory: IEngineManagerFactory = {
-    createPageManager: (engine, stateManager) => {
+    createPageManager: (engine, messageBus, stateManager) => {
       void engine
+      void messageBus
       void stateManager
       return { initialize: vi.fn(), switchPage: vi.fn(), cleanup: vi.fn() } as any
     },


### PR DESCRIPTION
## Summary
- ensure PageManager receives the MessageBus during creation
- wire MessageBus through GameEngineInitializer and app factory

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921b1c7dfc8332b691563cf80b8a0c