### PR TITLE
Fix translation service injection for input matrix

### DIFF
--- a/src/engine/gameEngineInitializer.ts
+++ b/src/engine/gameEngineInitializer.ts
@@ -20,7 +20,13 @@ export interface IEngineManagerFactory {
     createPageManager(engine: IGameEngine, messageBus: MessageBus, stateManager: IStateManager<ContextData>): IPageManager
     createMapManager(engine: IGameEngine, messageBus: MessageBus, stateManager: IStateManager<ContextData>): IMapManager
     createVirtualInputHandler(engine: IGameEngine, messageBus: MessageBus): IVirtualInputHandler
-    createInputManager(engine: IGameEngine, messageBus: MessageBus, stateManager: IStateManager<ContextData>): IInputManager
+    createInputManager(
+        engine: IGameEngine,
+        messageBus: MessageBus,
+        stateManager: IStateManager<ContextData>,
+        translationService: ITranslationService,
+        virtualInputHandler: IVirtualInputHandler
+    ): IInputManager
     createOutputManager(engine: IGameEngine, messageBus: MessageBus): IOutputManager
     createDialogManager(engine: IGameEngine, messageBus: MessageBus): IDialogManager
     createTranslationService(): ITranslationService
@@ -63,7 +69,7 @@ export class GameEngineInitializer {
         const pageManager = factory.createPageManager(engine, messageBus, stateManager)
         const mapManager = factory.createMapManager(engine, messageBus, stateManager)
         const virtualInputHandler = factory.createVirtualInputHandler(engine, messageBus)
-        const inputManager = factory.createInputManager(engine, messageBus, stateManager)
+        const inputManager = factory.createInputManager(engine, messageBus, stateManager, translationService, virtualInputHandler)
         const outputManager = factory.createOutputManager(engine, messageBus)
         const dialogManager = factory.createDialogManager(engine, messageBus)
 

--- a/src/engine/inputManagerService.ts
+++ b/src/engine/inputManagerService.ts
@@ -6,11 +6,15 @@ import type { Action } from '@loader/data/action'
 import type { IStateManager } from './stateManager'
 import type { ContextData } from './context'
 import type { IMessageBus } from '@utils/messageBus'
+import type { ITranslationService } from './translationService'
+import type { IVirtualInputHandler } from './virtualInputHandler'
 
 export function createInputManager(
     engine: IGameEngine,
     messageBus: IMessageBus,
-    stateManager: IStateManager<ContextData>
+    stateManager: IStateManager<ContextData>,
+    translationService: ITranslationService,
+    virtualInputHandler: IVirtualInputHandler
 ): IInputManager {
     const inputSourceTracker = new InputSourceTracker({
         messageBus,
@@ -19,8 +23,8 @@ export function createInputManager(
     })
 
     const inputMatrixBuilder = new InputMatrixBuilder({
-        translationService: engine.TranslationService,
-        virtualInputHandler: engine.VirtualInputHandler
+        translationService,
+        virtualInputHandler
     })
 
     const services: InputManagerServices = {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,7 +37,8 @@ const factory: IEngineManagerFactory = {
   createPageManager: (engine, messageBus, stateManager) => createPageManager(engine, messageBus, stateManager),
   createMapManager: (engine, messageBus, stateManager) => createMapManager(engine, messageBus, stateManager),
   createVirtualInputHandler: (engine, messageBus) => createVirtualInputHandler(engine, messageBus),
-  createInputManager: (engine, messageBus, stateManager) => createInputManager(engine, messageBus, stateManager),
+  createInputManager: (engine, messageBus, stateManager, translationService, virtualInputHandler) =>
+    createInputManager(engine, messageBus, stateManager, translationService, virtualInputHandler),
   createOutputManager: (engine, messageBus) => createOutputManager(engine, messageBus),
   createDialogManager: (engine, messageBus) => createDialogManager(engine, messageBus),
   createTranslationService: () => createTranslationService(),

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -30,10 +30,12 @@ function createEngine() {
       void messageBus
       return { initialize: vi.fn(), cleanup: vi.fn(), load: vi.fn(), getVirtualInput: vi.fn() } as any
     },
-    createInputManager: (engine, messageBus, stateManager) => {
+    createInputManager: (engine, messageBus, stateManager, translationService, virtualInputHandler) => {
       void engine
       void messageBus
       void stateManager
+      void translationService
+      void virtualInputHandler
       return { initialize: vi.fn(), cleanup: vi.fn(), update: vi.fn(), getInputMatrix: vi.fn() } as any
     },
     createOutputManager: (engine, messageBus) => {


### PR DESCRIPTION
## Summary
- Pass translation service and virtual input handler directly when creating the input manager to avoid undefined translations
- Update engine initialization and factory implementations to supply the required dependencies
- Adapt tests and main factory definitions to new createInputManager signature

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6892738176608332bcfcd85db6b40fcc