### PR TITLE
feat: add category-based logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,20 @@ Run the unit tests once with:
 npm test
 ```
 
+## Logging
+
+Control log output with environment variables:
+
+- `LOG_LEVEL` sets the minimum level that will be emitted (`debug`, `info`, `warning`, `error`). It defaults to `info`.
+- `LOG_DEBUG` enables debug messages for specific categories. Provide a comma-separated list such as `MessageBus,MapManager`.
+
+Examples:
+
+```bash
+# enable all debug logs
+LOG_LEVEL=debug npm run dev
+
+# enable debug logs only for MessageBus and MapManager
+LOG_LEVEL=debug LOG_DEBUG=MessageBus,MapManager npm run dev
+```
+

--- a/src/engine/core/gameEngine.ts
+++ b/src/engine/core/gameEngine.ts
@@ -117,7 +117,7 @@ export class GameEngine implements IGameEngine {
         await this.loader.reset()
         await this.registerGameHandlers()
         await this.virtualInputHandler.load()
-        const language = (this.currentLanguage ?? this.stateManager?.state.language) ?? fatalError('No language set!')
+        const language = (this.currentLanguage ?? this.stateManager?.state.language) ?? fatalError('GameEngine', 'No language set!')
         this.currentLanguage = language
         this.translationService.setLanguage(await this.loader.loadLanguage(language))
         this.state.value = GameEngineState.running
@@ -148,7 +148,7 @@ export class GameEngine implements IGameEngine {
     public executeAction(action: Action): void {
         const handler = this.actionHandlers.get(action.type)
         if (handler === undefined) {
-            fatalError(`No action handler for type: ${action.type}`)
+            fatalError('GameEngine', `No action handler for type: ${action.type}`)
         }
         handler.handle(this, action)
     }
@@ -157,7 +157,7 @@ export class GameEngine implements IGameEngine {
         if (condition === null) return true
         const resolver = this.conditionResolvers.get(condition.type)
         if (resolver === undefined) {
-            fatalError(`No condition resolver for type: ${condition.type}`)
+            fatalError('GameEngine', `No condition resolver for type: ${condition.type}`)
         }
         return resolver.resolve(this, condition)
     }
@@ -172,7 +172,7 @@ export class GameEngine implements IGameEngine {
     public setIsRunning(): void {
         this.loadCounter -= 1
         if (this.loadCounter < 0) {
-            fatalError('loadCounter cannot be negative')
+            fatalError('GameEngine', 'loadCounter cannot be negative')
         }
         if (this.loadCounter === 0) {
             this.State.value = GameEngineState.running
@@ -181,7 +181,7 @@ export class GameEngine implements IGameEngine {
 
     public get StateManager(): IStateManager<ContextData> {
         if (this.stateManager === null) {
-            fatalError('State manager is not initialized')
+            fatalError('GameEngine', 'State manager is not initialized')
         }
         return this.stateManager
     }

--- a/src/engine/core/stateManager.ts
+++ b/src/engine/core/stateManager.ts
@@ -84,7 +84,7 @@ export class StateManager<TData extends Record<string, unknown>> implements ISta
                         return value.bind(targetObj) as unknown
                     }
                     
-                    fatalError('State proxy cannot contain functions. Please use a different approach for {0}', currentPath)
+                    fatalError('StateManager', 'State proxy cannot contain functions. Please use a different approach for {0}', currentPath)
                 } else if (value !== null && typeof value === 'object') {
                     // create a proxy for the object
                     value = this.createStateProxy(value as Record<string, unknown>, currentPath)

--- a/src/engine/dialog/dialogManager.ts
+++ b/src/engine/dialog/dialogManager.ts
@@ -52,7 +52,7 @@ export class DialogManager implements IDialogManager {
             dialogId,
             async () => {
                 const loadedDialog = await this.services.loader.loadDialog(dialogId)
-                logDebug('DialogSet {0} loaded as {1}', dialogId, loadedDialog)
+                logDebug('DialogManager', 'DialogSet {0} loaded as {1}', dialogId, loadedDialog)
                 return loadedDialog
             },
             this.services.setIsLoading,
@@ -63,7 +63,7 @@ export class DialogManager implements IDialogManager {
 
         context.data.activeDialog = dialogId
 
-        logDebug('TODO: startDialog called with id = {0}', dialogId)
+        logDebug('DialogManager', 'TODO: startDialog called with id = {0}', dialogId)
         this.services.messageBus.postMessage({
             message: DIALOG_STARTED,
             payload: dialogId

--- a/src/engine/dialog/translationService.ts
+++ b/src/engine/dialog/translationService.ts
@@ -14,7 +14,7 @@ export class TranslationService implements ITranslationService {
     }
 
     public translate(key: string): string {
-        if (this.language === null) fatalError('No language was set!')
+        if (this.language === null) fatalError('TranslationService', 'No language was set!')
         return this.language.translations[key] ?? key
     }
 }

--- a/src/engine/input/virtualInputHandler.ts
+++ b/src/engine/input/virtualInputHandler.ts
@@ -69,7 +69,7 @@ export class VirtualInputHandler implements IVirtualInputHandler {
         const key = this.createKey(code, alt, ctrl, shift)
         const virtualKey = this.virtualKeys.get(key)
         if (virtualKey) {
-            logDebug('Virtual key: {0}', virtualKey.virtualKey)
+            logDebug('VirtualInputHandler', 'Virtual key: {0}', virtualKey.virtualKey)
             const virtualInput = this.virtualInputsByVirtualKey.get(virtualKey.virtualKey)
             if (virtualInput) {
                 this.services.messageBus.postMessage({
@@ -78,7 +78,7 @@ export class VirtualInputHandler implements IVirtualInputHandler {
                 })
             }
         } else {
-            logDebug('No virtual key for: code {0}, alt {1}, ctrl {2}, shift {3}', code, alt, ctrl, shift)
+            logDebug('VirtualInputHandler', 'No virtual key for: code {0}, alt {1}, ctrl {2}, shift {3}', code, alt, ctrl, shift)
         }
     }
 

--- a/src/engine/map/mapManager.ts
+++ b/src/engine/map/mapManager.ts
@@ -61,7 +61,7 @@ export class MapManager implements IMapManager {
             mapName,
             async () => {
                 const loadedMap = await this.services.loader.loadMap(mapName)
-                logDebug('map {0} loaded as {1}', mapName, loadedMap)
+                logDebug('MapManager', 'map {0} loaded as {1}', mapName, loadedMap)
                 return loadedMap
             },
             this.services.setIsLoading,
@@ -96,7 +96,7 @@ export class MapManager implements IMapManager {
             message: POSITION_CHANGED_MESSAGE,
             payload: { x: position.x, y: position.y },
         })
-        logDebug('Position set to x: {0}, y: {1}', position.x, position.y)
+        logDebug('MapManager', 'Position set to x: {0}, y: {1}', position.x, position.y)
         if (location.mapName === null) return
         const gameMap = context.maps[location.mapName]
         const tileId = gameMap.map[position.y][position.x]
@@ -115,7 +115,7 @@ export class MapManager implements IMapManager {
                 tileSetName,
                 async () => {
                     const tileSet = await this.services.loader.loadTileSet(tileSetName)
-                    logDebug('tile set {0} loaded as {1}', tileSetName, tileSet)
+                    logDebug('MapManager', 'tile set {0} loaded as {1}', tileSetName, tileSet)
                     tileSet.tiles.forEach(tile => context.tiles[tile.key] = tile)
                     return true
                 },

--- a/src/engine/page/pageManager.ts
+++ b/src/engine/page/pageManager.ts
@@ -51,7 +51,7 @@ export class PageManager implements IPageManager {
             page,
             async () => {
                 const pageData = await this.services.loader.loadPage(page)
-                logDebug('page {0} loaded as {1}', page, pageData)
+                logDebug('PageManager', 'page {0} loaded as {1}', page, pageData)
                 return pageData
             },
             this.services.setIsLoading,

--- a/src/engine/script/scriptRunner.ts
+++ b/src/engine/script/scriptRunner.ts
@@ -19,9 +19,9 @@ export class ScriptRunner implements IScriptRunner {
             return scriptFunction(context, data) as T
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error)
-            logInfo('Script content: {0}', script)
-            logInfo('Script context: {0}', context)
-            fatalError('Error executing script {0}', message)
+            logInfo('ScriptRunner', 'Script content: {0}', script)
+            logInfo('ScriptRunner', 'Script context: {0}', context)
+            fatalError('ScriptRunner', 'Error executing script {0}', message)
         }
     }
 }

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -61,7 +61,7 @@ export class Loader implements ILoader {
 
     public async loadRoot(): Promise<void> {
         await this.reset()
-        logDebug('Root loaded: {0}', this.root)
+        logDebug('Loader', 'Root loaded: {0}', this.root)
     }
 
     public async reset(): Promise<void> {
@@ -81,7 +81,7 @@ export class Loader implements ILoader {
     public async loadLanguage(language: string): Promise<LanguageData> {
         return this.loadWithCache(this.languages, language, async () => {
             const paths = this.game?.languages[language]
-            if (!paths) fatalError('Language {0} was not found!', language)
+            if (!paths) fatalError('Loader', 'Language {0} was not found!', language)
             const result: LanguageData = {
                 id: '',
                 translations: {}
@@ -90,7 +90,7 @@ export class Loader implements ILoader {
                 const schemaData = await loadJsonResource<Language>(`${this.basePath}/${path}`, languageSchema)
                 const languageData = mapLanguage(schemaData)
                 if (result.id === '') result.id = languageData.id
-                if (result.id !== languageData.id) logWarning('Unexpected language match {0} !== {1}', result.id, languageData.id)
+                if (result.id !== languageData.id) logWarning('Loader', 'Unexpected language match {0} !== {1}', result.id, languageData.id)
                 result.translations = { ...result.translations, ...languageData.translations }
             }
             return result
@@ -99,28 +99,28 @@ export class Loader implements ILoader {
 
     public async loadPage(page: string): Promise<PageData> {
         return this.loadWithCache(this.pages, page, async () => {
-            const path = this.game?.pages[page] ?? fatalError('Unknown page: {0}', page)
+            const path = this.game?.pages[page] ?? fatalError('Loader', 'Unknown page: {0}', page)
             return pageLoader({ basePath: this.basePath, path })
         })
     }
 
     public async loadTileSet(id: string): Promise<TileSetData> {
         return this.loadWithCache(this.tileSets, id, async () => {
-            const path = this.game?.tiles[id] ?? fatalError('Unknown tile set: {0}', id)
+            const path = this.game?.tiles[id] ?? fatalError('Loader', 'Unknown tile set: {0}', id)
             return tileLoader({ basePath: this.basePath, path })
         })
     }
 
     public async loadMap(id: string): Promise<MapData> {
         return this.loadWithCache(this.maps, id, async () => {
-            const path = this.game?.maps[id] ?? fatalError('Unknown map: {0}', id)
+            const path = this.game?.maps[id] ?? fatalError('Loader', 'Unknown map: {0}', id)
             return mapLoader({ basePath: this.basePath, path })
         })
     }
 
     public async loadDialog(id: string): Promise<DialogSet> {
         return this.loadWithCache(this.dialogs, id, async () => {
-            const path = this.game?.dialogs[id] ?? fatalError('Unknown dialog: {0}', id)
+            const path = this.game?.dialogs[id] ?? fatalError('Loader', 'Unknown dialog: {0}', id)
             return dialogLoader({ basePath: this.basePath, path })
         })
     }
@@ -139,7 +139,7 @@ export class Loader implements ILoader {
 
     public get Game(): GameData {
         if (this.game) return this.game
-        fatalError('No game root loaded yet')
+        fatalError('Loader', 'No game root loaded yet')
     }
 
     public get Styling(): string[] {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,7 @@ import './style/reset.css'
 import './style/variables.css'
 import './style/game.css'
 
-logDebug('Application starting ...')
+logDebug('Main', 'Application starting ...')
 
 const loader: ILoader = new Loader()
 await loader.loadRoot()

--- a/src/utils/loadJsonResource.ts
+++ b/src/utils/loadJsonResource.ts
@@ -2,17 +2,17 @@ import { ZodType } from 'zod'
 import { fatalError, logDebug } from './logMessage'
 
 export async function loadJsonResource<T>(url: string, schema: ZodType<T>): Promise<T> {
-    logDebug('Fetching JSON resource from {0}', url)
+    logDebug('LoadJsonResource', 'Fetching JSON resource from {0}', url)
     let response: Response
     try {
         response = await fetch(url)
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        fatalError('Failed to fetch {0} with message {1}', url, message)
+        fatalError('LoadJsonResource', 'Failed to fetch {0} with message {1}', url, message)
     }
 
     if (!response.ok) {
-        fatalError('Failed to fetch resource {0} with response {1}', url, response)
+        fatalError('LoadJsonResource', 'Failed to fetch resource {0} with response {1}', url, response)
     }
 
     let json: unknown
@@ -20,15 +20,15 @@ export async function loadJsonResource<T>(url: string, schema: ZodType<T>): Prom
         json = await response.json()
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        fatalError('Invalid JSON response: {0}', message)
+        fatalError('LoadJsonResource', 'Invalid JSON response: {0}', message)
     }
 
     const parseResult = schema.safeParse(json)
     if (!parseResult.success) {
-        fatalError('Schema validation failed for resource {0} with error {1}', url, parseResult.error.message)
+        fatalError('LoadJsonResource', 'Schema validation failed for resource {0} with error {1}', url, parseResult.error.message)
     }
 
-    logDebug('Resulting object: {0}', parseResult.data)
+    logDebug('LoadJsonResource', 'Resulting object: {0}', parseResult.data)
 
     return parseResult.data
 }

--- a/src/utils/logConfig.ts
+++ b/src/utils/logConfig.ts
@@ -1,0 +1,26 @@
+export const LogLevel = {
+    debug: 0,
+    info: 1,
+    warning: 2,
+    error: 3
+} as const
+export type LogLevel = typeof LogLevel[keyof typeof LogLevel]
+
+const currentLevelName = (process.env.LOG_LEVEL ?? 'info').toLowerCase()
+const currentLevel: LogLevel = (LogLevel as Record<string, LogLevel>)[currentLevelName] ?? LogLevel.info
+
+const categoriesEnv = process.env.LOG_DEBUG ?? ''
+const enabledCategories = new Set(
+    categoriesEnv
+        .split(',')
+        .map(c => c.trim())
+        .filter(c => c.length > 0)
+)
+
+export function isLevelEnabled(level: LogLevel): boolean {
+    return level >= currentLevel
+}
+
+export function isCategoryEnabled(category?: string): boolean {
+    return enabledCategories.size === 0 || category === undefined || enabledCategories.has(category)
+}

--- a/src/utils/trackedState.ts
+++ b/src/utils/trackedState.ts
@@ -37,7 +37,7 @@ export class TrackedValue<T> {
         if (this._value !== newValue) {
             const oldValue = this._value
             this._value = newValue
-            logDebug('TrackedValue {0} changed from {2} to {1}', this._name, newValue, oldValue)
+            logDebug('TrackedState', 'TrackedValue {0} changed from {2} to {1}', this._name, newValue, oldValue)
             this.subscribers.forEach(subscriber => subscriber())
             if (this._callback) {
                 this._callback(newValue, oldValue)

--- a/test/engine/inputManager.test.ts
+++ b/test/engine/inputManager.test.ts
@@ -41,6 +41,7 @@ function createInputManager(actionFn = vi.fn()) {
       page1: { id: 'page1', screen: { type: 'grid', width: 1, height: 1, components: [] }, inputs: [input] }
     },
     maps: {},
+    dialogs: {},
     tiles: {},
     tileSets: {},
     data: {

--- a/test/engine/mapManager.test.ts
+++ b/test/engine/mapManager.test.ts
@@ -33,6 +33,7 @@ function createMapManagerInstance() {
     language: 'en',
     pages: {},
     maps: {},
+    dialogs: {},
     tiles: {},
     tileSets: {},
     data: {

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -18,6 +18,7 @@ function createPageManagerInstance() {
     language: 'en',
     pages: {},
     maps: {},
+    dialogs: {},
     tiles: {},
     tileSets: {},
     data: {


### PR DESCRIPTION
## Summary
- support category-based logging with level & category filters
- wire categories through debug/info messages across engine
- document LOG_LEVEL and LOG_DEBUG usage

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893637ce0708332a4be798e12dd0067