### PR TITLE
fix: enable logging env vars in dev build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url))
 const withEditor = process.env.WITH_EDITOR !== 'false'
 
 export default defineConfig({
+  envPrefix: ['VITE_', 'LOG_'],
   plugins: [
     react(),
     viteStaticCopy({


### PR DESCRIPTION
## Summary
- expose `LOG_LEVEL` and `LOG_DEBUG` environment variables to the client by adjusting Vite's `envPrefix`

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68936dd40bd483328505a3df2cdc477e