### PR TITLE
Refactor loader into modular components

### DIFF
--- a/src/engine/core/gameEngine.ts
+++ b/src/engine/core/gameEngine.ts
@@ -1,6 +1,7 @@
 import { fatalError } from '@utils/logMessage'
 import { MessageBus, type IMessageBus } from '@utils/messageBus'
-import type { ILoader } from '@loader/loader'
+import type { ILoader, IGameLoader, ILanguageLoader, IHandlerLoader } from '@loader/loader'
+import type { Handler } from '@loader/data/handler'
 import { END_TURN_MESSAGE, ENGINE_STATE_CHANGED_MESSAGE, MAP_SWITCHED_MESSAGE, SWITCH_PAGE_MESSAGE } from '../messages/messages'
 import type { IStateManager } from './stateManager'
 import { TrackedValue, type ITrackedValue } from '@utils/trackedState'
@@ -51,7 +52,7 @@ export interface IGameEngine {
 }
 
 export class GameEngine implements IGameEngine {
-    private loader: ILoader
+    private loader: IGameLoader & ILanguageLoader & IHandlerLoader
     private messageBus!: MessageBus
     private stateManager: IStateManager<ContextData> | null = null
     private translationService!: ITranslationService
@@ -70,7 +71,7 @@ export class GameEngine implements IGameEngine {
     private actionHandlers = new Map<string, IActionHandler>()
     private conditionResolvers = new Map<string, IConditionResolver>()
 
-    constructor(loader: ILoader) {
+    constructor(loader: IGameLoader & ILanguageLoader & IHandlerLoader) {
         this.loader = loader
     }
 
@@ -195,7 +196,7 @@ export class GameEngine implements IGameEngine {
     }
 
     public get Loader(): ILoader {
-        return this.loader
+        return this.loader as ILoader
     }
 
     public get MessageBus(): IMessageBus {
@@ -246,7 +247,7 @@ export class GameEngine implements IGameEngine {
         const handlerFiles = this.loader.Game.handlers
         for (const path of handlerFiles) {
             const handlers = await this.loader.loadHandlers(path)
-            handlers.forEach(handler => {
+            handlers.forEach((handler: Handler) => {
                 const cleanup = this.messageBus.registerMessageListener(
                     handler.message,
                     () => this.executeAction(handler.action)

--- a/src/engine/dialog/dialogManager.ts
+++ b/src/engine/dialog/dialogManager.ts
@@ -3,7 +3,7 @@ import type { IMessageBus } from '@utils/messageBus'
 import { DIALOG_STARTED, START_DIALOG } from '../messages/messages'
 import type { IStateManager } from '@engine/core/stateManager'
 import type { ContextData } from '@engine/core/context'
-import type { ILoader } from '@loader/loader'
+import type { IDialogLoader } from '@loader/dialogLoader'
 import { loadOnce } from '@utils/loadOnce'
 import type { Condition } from '@loader/data/condition'
 
@@ -13,7 +13,7 @@ export interface IDialogManager {
 }
 
 export type DialogManagerServices = {
-    loader: ILoader
+    dialogLoader: IDialogLoader
     messageBus: IMessageBus
     stateManager: IStateManager<ContextData>
     setIsLoading: () => void
@@ -51,7 +51,7 @@ export class DialogManager implements IDialogManager {
             context.dialogs,
             dialogId,
             async () => {
-                const loadedDialog = await this.services.loader.loadDialog(dialogId)
+                const loadedDialog = await this.services.dialogLoader.loadDialog(dialogId)
                 logDebug('DialogManager', 'DialogSet {0} loaded as {1}', dialogId, loadedDialog)
                 return loadedDialog
             },

--- a/src/engine/dialog/dialogManagerService.ts
+++ b/src/engine/dialog/dialogManagerService.ts
@@ -3,6 +3,7 @@ import type { IGameEngine } from '../core/gameEngine'
 import { DialogManager, type DialogManagerServices, type IDialogManager } from './dialogManager'
 import type { IMessageBus } from '@utils/messageBus'
 import type { ContextData } from '@engine/core/context'
+import type { IDialogLoader } from '@loader/dialogLoader'
 
 export function createDialogManager(
     engine: IGameEngine,
@@ -10,7 +11,7 @@ export function createDialogManager(
     stateManager: IStateManager<ContextData>
 ): IDialogManager {
     const services: DialogManagerServices = {
-        loader: engine.Loader,
+        dialogLoader: engine.Loader as IDialogLoader,
         messageBus,
         stateManager,
         setIsLoading: () => engine.setIsLoading(),

--- a/src/engine/input/virtualInputHandler.ts
+++ b/src/engine/input/virtualInputHandler.ts
@@ -1,7 +1,8 @@
 import type { VirtualInput, VirtualKey } from '@loader/data/inputs'
 import { logDebug } from '@utils/logMessage'
 import { VIRTUAL_INPUT_MESSAGE } from '../messages/messages'
-import type { ILoader } from '@loader/loader'
+import type { IInputLoader } from '@loader/inputsLoader'
+import type { IGameLoader } from '@loader/loader'
 import type { IMessageBus } from '@utils/messageBus'
 
 export interface IVirtualInputHandler {
@@ -12,7 +13,8 @@ export interface IVirtualInputHandler {
 }
 
 export type VirtualInputHandlerServices = {
-    loader: ILoader
+    gameLoader: IGameLoader
+    inputLoader: IInputLoader
     messageBus: IMessageBus
 }
 
@@ -36,8 +38,8 @@ export class VirtualInputHandler implements IVirtualInputHandler {
 
     public async load(): Promise<void> {
         this.virtualKeys.clear()
-        for (const path of this.services.loader.Game.virtualKeys) {
-            const virtualKeys = await this.services.loader.loadVirtualKeys(path)
+        for (const path of this.services.gameLoader.Game.virtualKeys) {
+            const virtualKeys = await this.services.inputLoader.loadVirtualKeys(path)
             virtualKeys.forEach(virtualKey => {
                 const key = this.createKey(virtualKey.keyCode, virtualKey.alt, virtualKey.ctrl, virtualKey.shift)
                 this.virtualKeys.set(key, virtualKey)
@@ -46,8 +48,8 @@ export class VirtualInputHandler implements IVirtualInputHandler {
 
         this.virtualInputsByVirtualKey.clear()
         this.virtualInputs.clear()
-        for (const path of this.services.loader.Game.virtualInputs) {
-            const virtualInputs = await this.services.loader.loadVirtualInputs(path)
+        for (const path of this.services.gameLoader.Game.virtualInputs) {
+            const virtualInputs = await this.services.inputLoader.loadVirtualInputs(path)
             virtualInputs.forEach(virtualInput => {
                 this.virtualInputs.set(virtualInput.virtualInput, virtualInput)
                 virtualInput.virtualKeys.forEach(virtualKey => {

--- a/src/engine/input/virtualInputHandlerService.ts
+++ b/src/engine/input/virtualInputHandlerService.ts
@@ -1,10 +1,13 @@
 import type { IGameEngine } from '../core/gameEngine'
 import { VirtualInputHandler, type IVirtualInputHandler, type VirtualInputHandlerServices } from './virtualInputHandler'
 import type { IMessageBus } from '@utils/messageBus'
+import type { IGameLoader } from '@loader/loader'
+import type { IInputLoader } from '@loader/inputsLoader'
 
 export function createVirtualInputHandler(engine: IGameEngine, messageBus: IMessageBus): IVirtualInputHandler {
     const services: VirtualInputHandlerServices = {
-        loader: engine.Loader,
+        gameLoader: engine.Loader as IGameLoader,
+        inputLoader: engine.Loader as IInputLoader,
         messageBus
     }
     return new VirtualInputHandler(services)

--- a/src/engine/map/mapManager.ts
+++ b/src/engine/map/mapManager.ts
@@ -1,6 +1,7 @@
 import { logDebug } from '@utils/logMessage'
 import { loadOnce } from '@utils/loadOnce'
-import type { ILoader } from '@loader/loader'
+import type { IMapLoader } from '@loader/mapLoader'
+import type { ITileLoader } from '@loader/tileLoader'
 import type { IMessageBus } from '@utils/messageBus'
 import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
@@ -15,7 +16,8 @@ export interface IMapManager {
 }
 
 export type MapManagerServices = {
-    loader: ILoader
+    mapLoader: IMapLoader
+    tileLoader: ITileLoader
     messageBus: IMessageBus
     stateManager: IStateManager<ContextData>
     setIsLoading: () => void
@@ -60,7 +62,7 @@ export class MapManager implements IMapManager {
             context.maps,
             mapName,
             async () => {
-                const loadedMap = await this.services.loader.loadMap(mapName)
+                const loadedMap = await this.services.mapLoader.loadMap(mapName)
                 logDebug('MapManager', 'map {0} loaded as {1}', mapName, loadedMap)
                 return loadedMap
             },
@@ -114,7 +116,7 @@ export class MapManager implements IMapManager {
                 context.tileSets as Record<string, boolean>,
                 tileSetName,
                 async () => {
-                    const tileSet = await this.services.loader.loadTileSet(tileSetName)
+                    const tileSet = await this.services.tileLoader.loadTileSet(tileSetName)
                     logDebug('MapManager', 'tile set {0} loaded as {1}', tileSetName, tileSet)
                     tileSet.tiles.forEach(tile => context.tiles[tile.key] = tile)
                     return true

--- a/src/engine/map/mapManagerService.ts
+++ b/src/engine/map/mapManagerService.ts
@@ -4,6 +4,8 @@ import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
 import type { IMessageBus } from '@utils/messageBus'
 import type { Action } from '@loader/data/action'
+import type { IMapLoader } from '@loader/mapLoader'
+import type { ITileLoader } from '@loader/tileLoader'
 
 export function createMapManager(
     engine: IGameEngine,
@@ -11,7 +13,8 @@ export function createMapManager(
     stateManager: IStateManager<ContextData>
 ): IMapManager {
     const services: MapManagerServices = {
-        loader: engine.Loader,
+        mapLoader: engine.Loader as IMapLoader,
+        tileLoader: engine.Loader as ITileLoader,
         messageBus,
         stateManager,
         setIsLoading: () => engine.setIsLoading(),

--- a/src/engine/page/pageManager.ts
+++ b/src/engine/page/pageManager.ts
@@ -1,6 +1,6 @@
 import { logDebug } from '@utils/logMessage'
 import { loadOnce } from '@utils/loadOnce'
-import type { ILoader } from '@loader/loader'
+import type { IPageLoader } from '@loader/pageLoader'
 import type { IMessageBus } from '@utils/messageBus'
 import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
@@ -13,7 +13,7 @@ export interface IPageManager {
 }
 
 export type PageManagerServices = {
-    loader: ILoader
+    pageLoader: IPageLoader
     messageBus: IMessageBus
     stateManager: IStateManager<ContextData>
     setIsLoading: () => void
@@ -50,7 +50,7 @@ export class PageManager implements IPageManager {
             context.pages,
             page,
             async () => {
-                const pageData = await this.services.loader.loadPage(page)
+                const pageData = await this.services.pageLoader.loadPage(page)
                 logDebug('PageManager', 'page {0} loaded as {1}', page, pageData)
                 return pageData
             },

--- a/src/engine/page/pageManagerService.ts
+++ b/src/engine/page/pageManagerService.ts
@@ -3,6 +3,7 @@ import { PageManager, type IPageManager, type PageManagerServices } from './page
 import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
 import type { IMessageBus } from '@utils/messageBus'
+import type { IPageLoader } from '@loader/pageLoader'
 
 export function createPageManager(
     engine: IGameEngine,
@@ -10,7 +11,7 @@ export function createPageManager(
     stateManager: IStateManager<ContextData>
 ): IPageManager {
     const services: PageManagerServices = {
-        loader: engine.Loader,
+        pageLoader: engine.Loader as IPageLoader,
         messageBus,
         stateManager,
         setIsLoading: () => engine.setIsLoading(),

--- a/src/loader/dialogLoader.ts
+++ b/src/loader/dialogLoader.ts
@@ -3,6 +3,10 @@ import type { DialogSet as DialogSetData } from './data/dialog'
 import { dialogSetSchema, type DialogSet as DialogSetSchema } from './schema/dialog'
 import { mapDialogSet } from './mappers/dialog'
 
+export interface IDialogLoader {
+    loadDialog(id: string): Promise<DialogSetData>
+}
+
 interface Context {
     basePath: string
     path: string

--- a/src/loader/inputsLoader.ts
+++ b/src/loader/inputsLoader.ts
@@ -8,6 +8,11 @@ import {
 } from './schema/inputs'
 import { mapVirtualInputs, mapVirtualKeys } from './mappers/input'
 
+export interface IInputLoader {
+    loadVirtualKeys(path: string): Promise<VirtualKeys>
+    loadVirtualInputs(path: string): Promise<VirtualInputs>
+}
+
 export async function virtualKeysLoader(basePath: string, path: string): Promise<VirtualKeys> {
     const schemaData = await loadJsonResource<SchemaVirtualKeys>(`${basePath}/${path}`, virtualKeysSchema)
     return mapVirtualKeys(schemaData)

--- a/src/loader/languageLoader.ts
+++ b/src/loader/languageLoader.ts
@@ -1,0 +1,26 @@
+import { loadJsonResource } from '@utils/loadJsonResource'
+import { languageSchema, type Language } from './schema/language'
+import type { Language as LanguageData } from './data/language'
+import { mapLanguage } from './mappers/language'
+import { logWarning } from '@utils/logMessage'
+
+export interface ILanguageLoader {
+    loadLanguage(language: string): Promise<LanguageData>
+}
+
+export async function languageLoader(basePath: string, paths: string[]): Promise<LanguageData> {
+    const result: LanguageData = {
+        id: '',
+        translations: {},
+    }
+    for (const path of paths) {
+        const schemaData = await loadJsonResource<Language>(`${basePath}/${path}`, languageSchema)
+        const languageData = mapLanguage(schemaData)
+        if (result.id === '') result.id = languageData.id
+        if (result.id !== languageData.id) {
+            logWarning('LanguageLoader', 'Unexpected language match {0} !== {1}', result.id, languageData.id)
+        }
+        result.translations = { ...result.translations, ...languageData.translations }
+    }
+    return result
+}

--- a/src/loader/mapLoader.ts
+++ b/src/loader/mapLoader.ts
@@ -3,6 +3,10 @@ import type { GameMap as MapData } from './data/map'
 import { squaresMapSchema, type SquaresMap as SchemaSquaresMap } from './schema/map'
 import { mapGameMap } from './mappers/map'
 
+export interface IMapLoader {
+    loadMap(id: string): Promise<MapData>
+}
+
 interface Context {
     basePath: string
     path: string

--- a/src/loader/pageLoader.ts
+++ b/src/loader/pageLoader.ts
@@ -3,6 +3,10 @@ import type { Page as PageData } from './data/page'
 import { type Page, pageSchema } from './schema/page'
 import { mapPage } from './mappers/page'
 
+export interface IPageLoader {
+    loadPage(page: string): Promise<PageData>
+}
+
 interface Context {
     basePath: string
     path: string

--- a/src/loader/tileLoader.ts
+++ b/src/loader/tileLoader.ts
@@ -3,6 +3,10 @@ import type { TileSet as TileSetData } from './data/tile'
 import { tileSetSchema, type TileSet as SchemaTileSet } from './schema/tile'
 import { mapTile } from './mappers/tile'
 
+export interface ITileLoader {
+    loadTileSet(id: string): Promise<TileSetData>
+}
+
 function getDirectory(path: string): string {
     const idx = path.lastIndexOf('/')
     if (idx === -1) return ''

--- a/test/engine/mapManager.test.ts
+++ b/test/engine/mapManager.test.ts
@@ -55,7 +55,8 @@ function createMapManagerInstance() {
   const state = new TrackedValue<GameEngineState>('state', GameEngineState.init)
 
   const services: MapManagerServices = {
-    loader: loader as any,
+    mapLoader: loader as any,
+    tileLoader: loader as any,
     messageBus: messageBus as any,
     stateManager,
     setIsLoading: () => { state.value = GameEngineState.loading },

--- a/test/engine/pageManager.test.ts
+++ b/test/engine/pageManager.test.ts
@@ -34,7 +34,7 @@ function createPageManagerInstance() {
   const state = new TrackedValue<GameEngineState>('state', GameEngineState.init)
 
   const services: PageManagerServices = {
-    loader: loader as any,
+    pageLoader: loader as any,
     messageBus: messageBus as any,
     stateManager,
     setIsLoading: () => { state.value = GameEngineState.loading },


### PR DESCRIPTION
## Summary
- split loader responsibilities into domain interfaces and delegate modules
- add language loader and cache-aware delegation from Loader
- update managers and engine to depend on specific loader interfaces

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6893818461a48332bfd1d62018c7676c