### PR TITLE
feat: add component registry

### DIFF
--- a/src/app/components/componentRegistry.ts
+++ b/src/app/components/componentRegistry.ts
@@ -1,0 +1,22 @@
+import { GameMenu } from './gameMenu'
+import { Image } from './image'
+import { InputMatrix } from './inputMatrix'
+import { OutputLog } from './outputLog'
+import { SquaresMap } from './squaresMap'
+import type { ComponentType } from 'react'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const componentRegistry: Record<string, ComponentType<any>> = {
+    'game-menu': GameMenu,
+    'image': Image,
+    'squares-map': SquaresMap,
+    'input-matrix': InputMatrix,
+    'output-log': OutputLog,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const registerComponent = (type: string, component: ComponentType<any>): void => {
+    componentRegistry[type] = component
+}
+
+export default componentRegistry

--- a/src/app/controls/component.tsx
+++ b/src/app/controls/component.tsx
@@ -1,8 +1,4 @@
-import { GameMenu } from '@app/components/gameMenu'
-import { Image } from '@app/components/image'
-import { InputMatrix } from '@app/components/inputMatrix'
-import { OutputLog } from '@app/components/outputLog'
-import { SquaresMap } from '@app/components/squaresMap'
+import componentRegistry from '@app/components/componentRegistry'
 import type { Component as ComponentData } from '@loader/data/component'
 import type { IGameEngine } from '@engine/core/gameEngine'
 
@@ -11,19 +7,11 @@ export type ComponentProps = {
     engine: IGameEngine
 }
 
+const DefaultComponent: React.FC<ComponentProps> = ({ component }) => (
+    <div>TODO: {component.type}</div>
+)
+
 export const Component:React.FC<ComponentProps> = ({ component, engine }): React.JSX.Element => {
-    switch(component.type){
-        case 'game-menu':
-            return <GameMenu component={component} engine={engine} />
-        case 'image':
-            return <Image component={component} />
-        case 'squares-map':
-            return <SquaresMap component={component} engine={engine} />
-        case 'input-matrix':
-            return <InputMatrix component={component} engine={engine} />
-        case 'output-log':
-            return <OutputLog component={component} engine={engine} />
-        default:
-            return <div>TODO: {component.type}</div>
-    }
+    const ComponentImpl = componentRegistry[component.type] ?? DefaultComponent
+    return <ComponentImpl component={component} engine={engine} />
 }


### PR DESCRIPTION
## Summary
- add central registry mapping component types to implementations
- simplify Component control by using registry lookup with default fallback

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893818a38e483328533b8e3da5cf75d