### PR TITLE
refactor: modularize game engine

### DIFF
--- a/src/engine/core/handlerRegistry.ts
+++ b/src/engine/core/handlerRegistry.ts
@@ -1,0 +1,70 @@
+import { fatalError } from '@utils/logMessage'
+import { MessageBus } from '@utils/messageBus'
+import type { IGameLoader, IHandlerLoader } from '@loader/loader'
+import type { Handler } from '@loader/data/handler'
+import type { IActionHandler } from '../actions/actionHandler'
+import type { IConditionResolver } from '../conditions/conditionResolver'
+import type { Action } from '@loader/data/action'
+import type { Condition } from '@loader/data/condition'
+import type { CleanUp } from '@utils/types'
+import type { IGameEngine } from './gameEngine'
+
+export interface IHandlerRegistry {
+    registerActionHandler(handler: IActionHandler): void
+    registerConditionResolver(resolver: IConditionResolver): void
+    executeAction(engine: IGameEngine, action: Action): void
+    resolveCondition(engine: IGameEngine, condition: Condition | null): boolean
+    registerGameHandlers(engine: IGameEngine, loader: IGameLoader & IHandlerLoader, messageBus: MessageBus): Promise<void>
+    cleanup(): void
+}
+
+export class HandlerRegistry implements IHandlerRegistry {
+    private actionHandlers = new Map<string, IActionHandler>()
+    private conditionResolvers = new Map<string, IConditionResolver>()
+    private handlerCleanupList: CleanUp[] = []
+
+    public registerActionHandler(handler: IActionHandler): void {
+        this.actionHandlers.set(handler.type, handler)
+    }
+
+    public registerConditionResolver(resolver: IConditionResolver): void {
+        this.conditionResolvers.set(resolver.type, resolver)
+    }
+
+    public executeAction(engine: IGameEngine, action: Action): void {
+        const handler = this.actionHandlers.get(action.type)
+        if (handler === undefined) {
+            fatalError('HandlerRegistry', `No action handler for type: ${action.type}`)
+        }
+        handler.handle(engine, action)
+    }
+
+    public resolveCondition(engine: IGameEngine, condition: Condition | null): boolean {
+        if (condition === null) return true
+        const resolver = this.conditionResolvers.get(condition.type)
+        if (resolver === undefined) {
+            fatalError('HandlerRegistry', `No condition resolver for type: ${condition.type}`)
+        }
+        return resolver.resolve(engine, condition)
+    }
+
+    public async registerGameHandlers(engine: IGameEngine, loader: IGameLoader & IHandlerLoader, messageBus: MessageBus): Promise<void> {
+        this.cleanup()
+        const handlerFiles = loader.Game.handlers
+        for (const path of handlerFiles) {
+            const handlers = await loader.loadHandlers(path)
+            handlers.forEach((handler: Handler) => {
+                const cleanup = messageBus.registerMessageListener(
+                    handler.message,
+                    () => this.executeAction(engine, handler.action)
+                )
+                this.handlerCleanupList.push(cleanup)
+            })
+        }
+    }
+
+    public cleanup(): void {
+        this.handlerCleanupList.forEach(c => c())
+        this.handlerCleanupList = []
+    }
+}

--- a/src/engine/core/lifecycleManager.ts
+++ b/src/engine/core/lifecycleManager.ts
@@ -1,0 +1,100 @@
+import { fatalError } from '@utils/logMessage'
+import { MessageBus } from '@utils/messageBus'
+import { SWITCH_PAGE_MESSAGE, END_TURN_MESSAGE, ENGINE_STATE_CHANGED_MESSAGE, MAP_SWITCHED_MESSAGE } from '../messages/messages'
+import type { IGameLoader, ILanguageLoader, IHandlerLoader } from '@loader/loader'
+import type { IStateManager } from './stateManager'
+import type { ContextData } from './context'
+import type { ITranslationService } from '../dialog/translationService'
+import type { IPageManager } from '../page/pageManager'
+import type { IMapManager } from '../map/mapManager'
+import type { IVirtualInputHandler } from '../input/virtualInputHandler'
+import type { IInputManager } from '../input/inputManager'
+import type { IOutputManager } from '../output/outputManager'
+import type { IDialogManager } from '../dialog/dialogManager'
+import type { IHandlerRegistry } from './handlerRegistry'
+import { GameEngineState } from './stateController'
+import type { IStateController } from './stateController'
+import type { IGameEngine } from './gameEngine'
+
+export interface ILifecycleManager {
+    start(): Promise<void>
+    cleanup(): void
+}
+
+export class LifecycleManager implements ILifecycleManager {
+    private engine: IGameEngine
+    private loader: IGameLoader & ILanguageLoader & IHandlerLoader
+    private messageBus: MessageBus
+    private stateManager: IStateManager<ContextData>
+    private translationService: ITranslationService
+    private pageManager: IPageManager
+    private mapManager: IMapManager
+    private virtualInputHandler: IVirtualInputHandler
+    private inputManager: IInputManager
+    private outputManager: IOutputManager
+    private dialogManager: IDialogManager
+    private handlerRegistry: IHandlerRegistry
+    private stateController: IStateController
+    private currentLanguage: string | null = null
+
+    constructor(engine: IGameEngine, deps: {
+        loader: IGameLoader & ILanguageLoader & IHandlerLoader
+        messageBus: MessageBus
+        stateManager: IStateManager<ContextData>
+        translationService: ITranslationService
+        pageManager: IPageManager
+        mapManager: IMapManager
+        virtualInputHandler: IVirtualInputHandler
+        inputManager: IInputManager
+        outputManager: IOutputManager
+        dialogManager: IDialogManager
+        handlerRegistry: IHandlerRegistry
+        stateController: IStateController
+    }) {
+        this.engine = engine
+        this.loader = deps.loader
+        this.messageBus = deps.messageBus
+        this.stateManager = deps.stateManager
+        this.translationService = deps.translationService
+        this.pageManager = deps.pageManager
+        this.mapManager = deps.mapManager
+        this.virtualInputHandler = deps.virtualInputHandler
+        this.inputManager = deps.inputManager
+        this.outputManager = deps.outputManager
+        this.dialogManager = deps.dialogManager
+        this.handlerRegistry = deps.handlerRegistry
+        this.stateController = deps.stateController
+        this.initializeMessageListeners()
+    }
+
+    public async start(): Promise<void> {
+        this.stateController.State.value = GameEngineState.loading
+        await this.loader.reset()
+        await this.handlerRegistry.registerGameHandlers(this.engine, this.loader, this.messageBus)
+        await this.virtualInputHandler.load()
+        const language = (this.currentLanguage ?? this.stateManager.state.language) ?? fatalError('LifecycleManager', 'No language set!')
+        this.currentLanguage = language
+        this.translationService.setLanguage(await this.loader.loadLanguage(language))
+        this.stateController.State.value = GameEngineState.running
+        this.messageBus.postMessage({
+            message: SWITCH_PAGE_MESSAGE,
+            payload: this.loader.Game.initialData.startPage
+        })
+    }
+
+    public cleanup(): void {
+        this.pageManager.cleanup()
+        this.mapManager.cleanup()
+        this.virtualInputHandler.cleanup()
+        this.inputManager.cleanup()
+        this.outputManager.cleanup()
+        this.dialogManager.cleanup()
+        this.handlerRegistry.cleanup()
+    }
+
+    private initializeMessageListeners(): void {
+        this.messageBus.registerNotificationMessage(END_TURN_MESSAGE)
+        this.messageBus.registerNotificationMessage(ENGINE_STATE_CHANGED_MESSAGE)
+        this.messageBus.registerNotificationMessage(MAP_SWITCHED_MESSAGE)
+    }
+}

--- a/src/engine/core/stateController.ts
+++ b/src/engine/core/stateController.ts
@@ -1,0 +1,62 @@
+import { fatalError } from '@utils/logMessage'
+import { MessageBus } from '@utils/messageBus'
+import { TrackedValue, type ITrackedValue } from '@utils/trackedState'
+import { ENGINE_STATE_CHANGED_MESSAGE } from '../messages/messages'
+
+export const GameEngineState = {
+    init: 0,
+    loading: 1,
+    running: 2
+} as const
+export type GameEngineState = typeof GameEngineState[keyof typeof GameEngineState]
+
+export interface IStateController {
+    readonly State: ITrackedValue<GameEngineState>
+    setIsLoading(): void
+    setIsRunning(): void
+}
+
+export class StateController implements IStateController {
+    private state: ITrackedValue<GameEngineState>
+    private loadCounter = 0
+    private messageBus: MessageBus
+
+    constructor(messageBus: MessageBus) {
+        this.messageBus = messageBus
+        this.state = new TrackedValue<GameEngineState>(
+            'GameEngine.State',
+            GameEngineState.init,
+            (newValue, oldValue) => {
+                this.messageBus.postMessage({
+                    message: ENGINE_STATE_CHANGED_MESSAGE,
+                    payload: {
+                        oldState: oldValue,
+                        newState: newValue
+                    }
+                })
+            }
+        )
+    }
+
+    public get State(): ITrackedValue<GameEngineState> {
+        return this.state
+    }
+
+    public setIsLoading(): void {
+        this.loadCounter += 1
+        if (this.loadCounter === 1) {
+            this.state.value = GameEngineState.loading
+        }
+    }
+
+    public setIsRunning(): void {
+        this.loadCounter -= 1
+        if (this.loadCounter < 0) {
+            fatalError('StateController', 'loadCounter cannot be negative')
+        }
+        if (this.loadCounter === 0) {
+            this.state.value = GameEngineState.running
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- split GameEngine into lifecycle, handler registry, and state controller modules
- inject new modules so GameEngine orchestrates them
- wire lifecycle, handler, and state modules in gameEngineInitializer

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6893947d39f08332a5f1db979d93e7ee