### PR TITLE
refactor: extract state proxy helpers

### DIFF
--- a/src/engine/core/stateProxyHelpers.ts
+++ b/src/engine/core/stateProxyHelpers.ts
@@ -1,0 +1,29 @@
+import type { IChangeTracker, Primitive } from './changeTracker'
+
+export const getCachedProxy = <T extends Record<string, unknown>>(cache: WeakMap<object, unknown>, target: T): T | undefined => {
+    return cache.get(target) as T | undefined
+}
+
+export const cacheProxy = <T extends Record<string, unknown>>(cache: WeakMap<object, unknown>, target: T, proxy: T): void => {
+    cache.set(target, proxy)
+}
+
+export const buildPath = (path: string | null, prop: string | symbol): string => {
+    return path ? `${path}.${String(prop)}` : String(prop)
+}
+
+export const trackChange = <TData extends Record<string, unknown>>(changeTracker: IChangeTracker<TData>, path: string, newValue: unknown, oldValue: unknown): void => {
+    if (newValue !== null && typeof newValue === 'object') {
+        const oldClone = oldValue === undefined ? null : JSON.parse(JSON.stringify(oldValue))
+        const newClone = JSON.parse(JSON.stringify(newValue))
+        changeTracker.trackChange({ path, newValue: newClone as Primitive, oldValue: oldClone as Primitive })
+    } else if (
+        oldValue === null ||
+        oldValue === undefined ||
+        typeof oldValue === 'string' ||
+        typeof oldValue === 'number' ||
+        typeof oldValue === 'boolean'
+    ) {
+        changeTracker.trackChange({ path, newValue: newValue as Primitive, oldValue: (oldValue ?? null) as Primitive })
+    }
+}

--- a/test/engine/stateProxyHelpers.test.ts
+++ b/test/engine/stateProxyHelpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { ChangeTracker } from '@engine/core/changeTracker'
+import { buildPath, cacheProxy, getCachedProxy, trackChange } from '@engine/core/stateProxyHelpers'
+
+describe('stateProxyHelpers', () => {
+  it('builds paths correctly', () => {
+    expect(buildPath(null, 'prop')).toBe('prop')
+    expect(buildPath('parent', 'child')).toBe('parent.child')
+  })
+
+  it('caches and retrieves proxies', () => {
+    const cache = new WeakMap<object, unknown>()
+    const target: Record<string, unknown> = {}
+    const proxy: Record<string, unknown> = { a: 1 }
+    expect(getCachedProxy(cache, target)).toBeUndefined()
+    cacheProxy(cache, target, proxy)
+    expect(getCachedProxy(cache, target)).toBe(proxy)
+  })
+
+  it('tracks primitive and object changes', () => {
+    interface Data extends Record<string, unknown> { value: unknown }
+    const tracker = new ChangeTracker<Data>()
+    trackChange(tracker, 'value', 1, null)
+    const objOld = { a: 0 }
+    const objNew = { a: 1 }
+    trackChange(tracker, 'value', objNew, objOld)
+    const changes = tracker.changes[tracker.activeTurnIndex].changes
+    expect(changes[0]).toEqual({ path: 'value', newValue: 1, oldValue: null })
+    expect(changes[1]).toEqual({ path: 'value', newValue: { a: 1 }, oldValue: { a: 0 } })
+  })
+})


### PR DESCRIPTION
## Summary
- move proxy caching, path building, and change tracking logic into dedicated `stateProxyHelpers`
- simplify `StateManager` proxy creation using extracted helpers
- add unit tests for new proxy helpers

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689394946cb88332b542c186f0cc6879