### PR TITLE
refactor: extract map loading service

### DIFF
--- a/src/engine/map/mapLoaderService.ts
+++ b/src/engine/map/mapLoaderService.ts
@@ -1,0 +1,101 @@
+import { logDebug } from '@utils/logMessage'
+import { loadOnce } from '@utils/loadOnce'
+import type { IMapLoader } from '@loader/mapLoader'
+import type { ITileLoader } from '@loader/tileLoader'
+import type { IMessageBus } from '@utils/messageBus'
+import type { IStateManager } from '../core/stateManager'
+import type { ContextData } from '../core/context'
+import { CHANGE_POSITION_MESSAGE, MAP_SWITCHED_MESSAGE, SWITCH_MAP_MESSAGE } from '../messages/messages'
+import type { GameMap } from '@loader/data/map'
+import type { SwitchMapPayload } from '@engine/messages/types'
+
+export interface IMapLoaderService {
+    initialize(): void
+    cleanup(): void
+}
+
+export type MapLoaderServiceDependencies = {
+    mapLoader: IMapLoader
+    tileLoader: ITileLoader
+    messageBus: IMessageBus
+    stateManager: IStateManager<ContextData>
+    setIsLoading: () => void
+    setIsRunning: () => void
+}
+
+export class MapLoaderService implements IMapLoaderService {
+    private unregisterEventHandlers: (() => void)[] = []
+    private deps: MapLoaderServiceDependencies
+
+    constructor(deps: MapLoaderServiceDependencies) {
+        this.deps = deps
+    }
+
+    public initialize(): void {
+        this.unregisterEventHandlers.push(
+            this.deps.messageBus.registerMessageListener(
+                SWITCH_MAP_MESSAGE,
+                async (message) => this.switchMap(message.payload as unknown as SwitchMapPayload)
+            )
+        )
+    }
+
+    public cleanup(): void {
+        this.unregisterEventHandlers.forEach(unregister => unregister())
+        this.unregisterEventHandlers = []
+    }
+
+    private async switchMap(switchMap: SwitchMapPayload): Promise<void> {
+        const context = this.deps.stateManager.state
+        const mapName = switchMap.mapName
+        if (context.data.location.mapName === mapName) return
+
+        const mapData = await loadOnce(
+            context.maps,
+            mapName,
+            async () => {
+                const loadedMap = await this.deps.mapLoader.loadMap(mapName)
+                logDebug('MapLoaderService', 'map {0} loaded as {1}', mapName, loadedMap)
+                return loadedMap
+            },
+            this.deps.setIsLoading,
+            this.deps.setIsRunning,
+        )
+
+        context.data.location.mapName = mapName
+        context.data.location.mapSize.width = mapData.width
+        context.data.location.mapSize.height = mapData.height
+        await this.loadAdditionalMapData(mapData)
+        this.deps.messageBus.postMessage({
+            message: MAP_SWITCHED_MESSAGE,
+            payload: mapName
+        })
+        if (switchMap.position) {
+            this.deps.messageBus.postMessage({
+                message: CHANGE_POSITION_MESSAGE,
+                payload: {
+                    x: switchMap.position.x,
+                    y: switchMap.position.y
+                }
+            })
+        }
+    }
+
+    private async loadAdditionalMapData(mapData: GameMap): Promise<void> {
+        const context = this.deps.stateManager.state
+        for (const tileSetName of mapData.tileSets) {
+            await loadOnce(
+                context.tileSets as Record<string, boolean>,
+                tileSetName,
+                async () => {
+                    const tileSet = await this.deps.tileLoader.loadTileSet(tileSetName)
+                    logDebug('MapLoaderService', 'tile set {0} loaded as {1}', tileSetName, tileSet)
+                    tileSet.tiles.forEach(tile => context.tiles[tile.key] = tile)
+                    return true
+                },
+                this.deps.setIsLoading,
+                this.deps.setIsRunning,
+            )
+        }
+    }
+}

--- a/src/engine/map/mapManager.ts
+++ b/src/engine/map/mapManager.ts
@@ -1,14 +1,11 @@
-import { logDebug } from '@utils/logMessage'
-import { loadOnce } from '@utils/loadOnce'
-import type { IMapLoader } from '@loader/mapLoader'
-import type { ITileLoader } from '@loader/tileLoader'
 import type { IMessageBus } from '@utils/messageBus'
+import { logDebug } from '@utils/logMessage'
 import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
-import { CHANGE_POSITION_MESSAGE, MAP_SWITCHED_MESSAGE, POSITION_CHANGED_MESSAGE, SWITCH_MAP_MESSAGE } from '../messages/messages'
-import type { GameMap } from '@loader/data/map'
-import type { ChangePositionPayload, SwitchMapPayload } from '@engine/messages/types'
+import { CHANGE_POSITION_MESSAGE, POSITION_CHANGED_MESSAGE } from '../messages/messages'
+import type { ChangePositionPayload } from '@engine/messages/types'
 import type { Action } from '@loader/data/action'
+import type { IMapLoaderService } from './mapLoaderService'
 
 export interface IMapManager {
     initialize(): void
@@ -16,13 +13,10 @@ export interface IMapManager {
 }
 
 export type MapManagerServices = {
-    mapLoader: IMapLoader
-    tileLoader: ITileLoader
     messageBus: IMessageBus
     stateManager: IStateManager<ContextData>
-    setIsLoading: () => void
-    setIsRunning: () => void
     executeAction: (action: Action) => void
+    mapLoaderService: IMapLoaderService
 }
 
 export class MapManager implements IMapManager {
@@ -34,12 +28,7 @@ export class MapManager implements IMapManager {
     }
 
     public initialize(): void {
-        this.unregisterEventHandlers.push(
-            this.services.messageBus.registerMessageListener(
-                SWITCH_MAP_MESSAGE,
-                async (message) => this.switchMap(message.payload as unknown as SwitchMapPayload)
-            )
-        )
+        this.services.mapLoaderService.initialize()
         this.unregisterEventHandlers.push(
             this.services.messageBus.registerMessageListener(
                 CHANGE_POSITION_MESSAGE,
@@ -49,44 +38,9 @@ export class MapManager implements IMapManager {
     }
 
     public cleanup(): void {
+        this.services.mapLoaderService.cleanup()
         this.unregisterEventHandlers.forEach(unregister => unregister())
         this.unregisterEventHandlers = []
-    }
-
-    private async switchMap(switchMap: SwitchMapPayload): Promise<void> {
-        const context = this.services.stateManager.state
-        const mapName = switchMap.mapName
-        if (context.data.location.mapName === mapName) return
-
-        const mapData = await loadOnce(
-            context.maps,
-            mapName,
-            async () => {
-                const loadedMap = await this.services.mapLoader.loadMap(mapName)
-                logDebug('MapManager', 'map {0} loaded as {1}', mapName, loadedMap)
-                return loadedMap
-            },
-            this.services.setIsLoading,
-            this.services.setIsRunning,
-        )
-
-        context.data.location.mapName = mapName
-        context.data.location.mapSize.width = mapData.width
-        context.data.location.mapSize.height = mapData.height
-        await this.loadAdditionalMapData(mapData)
-        this.services.messageBus.postMessage({
-            message: MAP_SWITCHED_MESSAGE,
-            payload: mapName
-        })
-        if (switchMap.position) {
-            this.services.messageBus.postMessage({
-                message: CHANGE_POSITION_MESSAGE,
-                payload: {
-                    x: switchMap.position.x,
-                    y: switchMap.position.y
-                }
-            })
-        }
     }
 
     private async changePosition(position: { x: number; y: number }): Promise<void> {
@@ -105,25 +59,6 @@ export class MapManager implements IMapManager {
         const tile = gameMap.tiles[tileId]
         if (tile.onEnter) {
             this.services.executeAction(tile.onEnter)
-        }
-    }
-
-
-    private async loadAdditionalMapData(mapData: GameMap): Promise<void> {
-        const context = this.services.stateManager.state
-        for (const tileSetName of mapData.tileSets) {
-            await loadOnce(
-                context.tileSets as Record<string, boolean>,
-                tileSetName,
-                async () => {
-                    const tileSet = await this.services.tileLoader.loadTileSet(tileSetName)
-                    logDebug('MapManager', 'tile set {0} loaded as {1}', tileSetName, tileSet)
-                    tileSet.tiles.forEach(tile => context.tiles[tile.key] = tile)
-                    return true
-                },
-                this.services.setIsLoading,
-                this.services.setIsRunning,
-            )
         }
     }
 }

--- a/src/engine/map/mapManagerService.ts
+++ b/src/engine/map/mapManagerService.ts
@@ -6,20 +6,28 @@ import type { IMessageBus } from '@utils/messageBus'
 import type { Action } from '@loader/data/action'
 import type { IMapLoader } from '@loader/mapLoader'
 import type { ITileLoader } from '@loader/tileLoader'
+import { MapLoaderService, type MapLoaderServiceDependencies } from './mapLoaderService'
 
 export function createMapManager(
     engine: IGameEngine,
     messageBus: IMessageBus,
     stateManager: IStateManager<ContextData>
 ): IMapManager {
-    const services: MapManagerServices = {
+    const loaderServices: MapLoaderServiceDependencies = {
         mapLoader: engine.Loader as IMapLoader,
         tileLoader: engine.Loader as ITileLoader,
         messageBus,
         stateManager,
         setIsLoading: () => engine.setIsLoading(),
         setIsRunning: () => engine.setIsRunning(),
-        executeAction: (action: Action) => engine.executeAction(action)
+    }
+    const mapLoaderService = new MapLoaderService(loaderServices)
+
+    const services: MapManagerServices = {
+        messageBus,
+        stateManager,
+        executeAction: (action: Action) => engine.executeAction(action),
+        mapLoaderService,
     }
     return new MapManager(services)
 }

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -23,7 +23,7 @@ function createEngine() {
       void engine
       void messageBus
       void stateManager
-      return { initialize: vi.fn(), switchMap: vi.fn(), cleanup: vi.fn() } as any
+      return { initialize: vi.fn(), cleanup: vi.fn() } as any
     },
     createVirtualInputHandler: (engine, messageBus) => {
       void engine


### PR DESCRIPTION
## Summary
- add MapLoaderService to handle SWITCH_MAP_MESSAGE events and tile-set loading
- delegate position updates to MapManager while initializing/cleaning MapLoaderService
- update tests for new MapLoaderService

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6893e18d50c88332bedd46ca77c85b10