### PR TITLE
refactor: modularize game editor logic

### DIFF
--- a/src/editor/components/GameEditor.tsx
+++ b/src/editor/components/GameEditor.tsx
@@ -1,255 +1,31 @@
-import { useEffect, useState } from 'react'
-import { gameSchema } from '@loader/schema/game'
+import type React from 'react'
 import type { Game } from '@loader/data/game'
-import { saveGame } from '../main'
-import { LanguageList } from './LanguageList'
-import { PageList } from './PageList'
-import { MapList } from './MapList'
-import { MapEditor } from './MapEditor'
-import { TileList } from './TileList'
-import { DialogList } from './DialogList'
-import { StylingList } from './StylingList'
-import { HandlerList } from './HandlerList'
-import { VirtualKeyList } from './VirtualKeyList'
-import { VirtualInputList } from './VirtualInputList'
-import { useEditableList } from './useEditableList'
-import type { GameMap } from '@loader/data/map'
-import type { Tile } from '@loader/data/tile'
-import { resolveTileSet } from '../resolveTileSet'
-import { fromAnyMap, toSchemaMap } from '../convertMap'
+import { useGameData } from '../hooks/useGameData'
+import { useGameTabs } from '../hooks/useGameTabs'
+import { GameForm } from './GameForm'
+import { MapEditorPanel } from './MapEditorPanel'
 
 export const GameEditor: React.FC = () => {
-  const [game, setGame] = useState<Game | null>(null)
-  const [styling, setStyling] = useState<string[]>([])
-  const [statusMessage, setStatusMessage] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [loadError, setLoadError] = useState('')
-  const [tab, setTab] = useState<'game' | 'map'>('game')
-  const [editingMap, setEditingMap] = useState<GameMap | null>(null)
-  const [editingTiles, setEditingTiles] = useState<Record<string, Tile>>({})
-  const [editingMapId, setEditingMapId] = useState<string | null>(null)
-  useEffect(() => {
-    const controller = new AbortController()
+  const {
+    game,
+    setGame,
+    styling,
+    setStyling,
+    statusMessage,
+    setStatusMessage,
+    loadError,
+    saving,
+    save,
+  } = useGameData()
 
-    const load = async () => {
-      try {
-        const response = await fetch('/api/game', {
-          signal: controller.signal,
-        })
-
-        if (!response.ok) {
-          setLoadError('Failed to load game data.')
-          setGame({
-            title: '',
-            description: '',
-            version: '',
-            initialData: { language: '', startPage: '' },
-            languages: {},
-            pages: {},
-            maps: {},
-            tiles: {},
-            dialogs: {},
-            handlers: [],
-            virtualKeys: [],
-            virtualInputs: [],
-          })
-          setStyling([])
-          return
-        }
-
-        const data = await response.json()
-        const parsed = gameSchema.parse(data)
-        const result: Game = {
-          title: parsed.title,
-          description: parsed.description,
-          version: parsed.version,
-          initialData: {
-            language: parsed['initial-data'].language,
-            startPage: parsed['initial-data']['start-page'],
-          },
-          languages: { ...parsed.languages },
-          pages: { ...parsed.pages },
-          maps: { ...parsed.maps },
-          tiles: { ...parsed.tiles },
-          dialogs: { ...parsed.dialogs },
-          handlers: [...parsed.handlers],
-          virtualKeys: [...parsed['virtual-keys']],
-          virtualInputs: [...parsed['virtual-inputs']],
-        }
-        setGame(result)
-        setStyling(parsed.styling)
-      } catch (err) {
-        if ((err as Error).name === 'AbortError') return
-        setLoadError('Failed to load game data.')
-        setGame({
-          title: '',
-          description: '',
-          version: '',
-          initialData: { language: '', startPage: '' },
-          languages: {},
-          pages: {},
-          maps: {},
-          dialogs: {},
-          tiles: {},
-          handlers: [],
-          virtualKeys: [],
-          virtualInputs: [],
-        })
-        setStyling([])
-      }
-    }
-
-    load()
-    return () => controller.abort()
-  }, [])
-  const setLanguageMap = (
-    updater: React.SetStateAction<Record<string, string[]>>,
-  ) =>
-    setGame((g) => {
-      if (!g) return g
-      const value = typeof updater === 'function' ? updater(g.languages) : updater
-      return { ...g, languages: value }
-    })
-
-  const setMap = <K extends 'pages' | 'maps' | 'tiles' | 'dialogs'>(key: K) =>
-    (updater: React.SetStateAction<Record<string, string>>) =>
-      setGame((g) => {
-        if (!g) return g
-        const value =
-          typeof updater === 'function' ? updater(g[key]) : updater
-        return { ...g, [key]: value }
-      })
-
-  const setArray = <
-    K extends 'handlers' | 'virtualKeys' | 'virtualInputs'
-  >(key: K) => (updater: React.SetStateAction<string[]>) =>
-    setGame((g) => {
-      if (!g) return g
-      const value =
-        typeof updater === 'function' ? updater(g[key]) : updater
-      return { ...g, [key]: value }
-    })
-
-  const languageActions = useEditableList<string[]>(setLanguageMap, {
-    type: 'map',
-    prefix: 'language',
-    empty: [],
-  })
-  const pageActions = useEditableList(setMap('pages'), {
-    type: 'map',
-    prefix: 'page',
-    empty: '',
-  })
-  const mapActions = useEditableList(setMap('maps'), {
-    type: 'map',
-    prefix: 'map',
-    empty: '',
-  })
-  const tileActions = useEditableList(setMap('tiles'), {
-    type: 'map',
-    prefix: 'tile',
-    empty: '',
-  })
-  const dialogActions = useEditableList(setMap('dialogs'), {
-    type: 'map',
-    prefix: 'dialog',
-    empty: '',
-  })
-
-  const stylingActions = useEditableList(setStyling, { type: 'array' })
-  const handlerActions = useEditableList(setArray('handlers'), {
-    type: 'array',
-  })
-  const virtualKeyActions = useEditableList(setArray('virtualKeys'), {
-    type: 'array',
-  })
-  const virtualInputActions = useEditableList(setArray('virtualInputs'), {
-    type: 'array',
-  })
-
-  const openMapEditor = async (id: string) => {
-    if (!game) return
-    const path = game.maps[id]
-    let mapData: GameMap
-    let tiles: Record<string, Tile> = {}
-    try {
-      const res = await fetch(`/api/map/${encodeURIComponent(path)}`)
-      if (!res.ok) throw new Error('failed')
-      const json = await res.json()
-      mapData = fromAnyMap(json)
-      await Promise.all(
-        (mapData.tileSets || []).map(async (setId: string) => {
-          const tilePath = game.tiles[setId]
-          if (!tilePath) return
-          const tRes = await fetch(
-            `/api/map/${encodeURIComponent(tilePath)}`,
-          )
-          if (!tRes.ok) return
-          const tJson = await tRes.json()
-          if (Array.isArray(tJson.tiles)) {
-            Object.assign(tiles, resolveTileSet(tilePath, tJson.tiles as Tile[]))
-          }
-        }),
-      )
-    } catch {
-      mapData = {
-        key: id,
-        type: 'squares-map',
-        width: 1,
-        height: 1,
-        tileSets: [],
-        tiles: { blank: { key: 'blank', tile: 'blank' } },
-        map: [['blank']],
-      }
-      tiles = {
-        blank: { key: 'blank', description: '', color: 'transparent' },
-      }
-      setStatusMessage('Failed to load map')
-    }
-    setEditingMapId(id)
-    setEditingMap(mapData)
-    setEditingTiles(tiles)
-    setTab('map')
-  }
-
-  const handleMapSave = async (map: GameMap, tiles: Record<string, Tile>) => {
-    if (!game || !editingMapId) return
-    const json = JSON.stringify({ map: toSchemaMap(map), tiles }, null, 2)
-    const path = game.maps[editingMapId]
-    const message = await saveGame(
-      json,
-      (_url, options) => fetch(`/api/map/${encodeURIComponent(path)}`, options),
-    )
-    setStatusMessage(message)
-    setTab('game')
-  }
-
-  const handleSave = async () => {
-    if (!game) return
-    const obj = {
-      title: game.title,
-      description: game.description,
-      version: game.version,
-      'initial-data': {
-        language: game.initialData.language,
-        'start-page': game.initialData.startPage,
-      },
-      languages: game.languages,
-      pages: game.pages,
-      maps: game.maps,
-      tiles: game.tiles,
-      dialogs: game.dialogs,
-      styling,
-      handlers: game.handlers,
-      'virtual-keys': game.virtualKeys,
-      'virtual-inputs': game.virtualInputs,
-    }
-    const json = JSON.stringify(obj, null, 2)
-    setSaving(true)
-    const message = await saveGame(json)
-    setStatusMessage(message)
-    setSaving(false)
-  }
+  const {
+    tab,
+    setTab,
+    editingMap,
+    editingTiles,
+    openMapEditor,
+    handleMapSave,
+  } = useGameTabs(game, setStatusMessage)
 
   if (!game) return <div>Loading...</div>
 
@@ -266,83 +42,19 @@ export const GameEditor: React.FC = () => {
         </button>
       </nav>
       {tab === 'game' && (
-        <>
-          <fieldset className="editor-section">
-            <label>
-              Title:
-              <input
-                type="text"
-                value={game.title}
-            onChange={(e) => setGame({ ...game, title: e.target.value })}
-          />
-        </label>
-        <label>
-          Description:
-          <textarea
-            value={game.description}
-            onChange={(e) => setGame({ ...game, description: e.target.value })}
-          />
-        </label>
-        <label>
-          Version:
-          <input
-            type="text"
-            value={game.version}
-            onChange={(e) => setGame({ ...game, version: e.target.value })}
-          />
-        </label>
-          </fieldset>
-          <fieldset className="editor-section">
-            <label>
-              Initial Language:
-              <input
-                type="text"
-                value={game.initialData.language}
-            onChange={(e) =>
-              setGame({
-                ...game,
-                initialData: { ...game.initialData, language: e.target.value },
-              })
-            }
-          />
-        </label>
-        <label>
-          Start Page:
-          <input
-            type="text"
-            value={game.initialData.startPage}
-            onChange={(e) =>
-              setGame({
-                ...game,
-                initialData: { ...game.initialData, startPage: e.target.value },
-              })
-            }
-          />
-            </label>
-          </fieldset>
-          <LanguageList languages={game.languages} {...languageActions} />
-          <PageList pages={game.pages} {...pageActions} />
-          <MapList maps={game.maps} onEdit={openMapEditor} {...mapActions} />
-          <TileList tiles={game.tiles} {...tileActions} />
-          <DialogList dialogs={game.dialogs} {...dialogActions} />
-          <StylingList styling={styling} {...stylingActions} />
-          <HandlerList handlers={game.handlers} {...handlerActions} />
-          <VirtualKeyList
-            virtualKeys={game.virtualKeys}
-            {...virtualKeyActions}
-          />
-          <VirtualInputList
-            virtualInputs={game.virtualInputs}
-            {...virtualInputActions}
-          />
-          <button type="button" onClick={handleSave} disabled={saving}>
-            Save
-          </button>
-        </>
+        <GameForm
+          game={game}
+          setGame={setGame as React.Dispatch<React.SetStateAction<Game>>}
+          styling={styling}
+          setStyling={setStyling}
+          openMapEditor={openMapEditor}
+          onSave={save}
+          saving={saving}
+        />
       )}
       {tab === 'map' && editingMap && (
-        <MapEditor
-          key={editingMapId ?? undefined}
+        <MapEditorPanel
+          key={editingMap.key}
           map={editingMap}
           tiles={editingTiles}
           onSave={handleMapSave}
@@ -354,4 +66,3 @@ export const GameEditor: React.FC = () => {
     </section>
   )
 }
-

--- a/src/editor/components/GameForm.tsx
+++ b/src/editor/components/GameForm.tsx
@@ -1,0 +1,154 @@
+import type React from 'react'
+import type { Game } from '@loader/data/game'
+import { LanguageList } from './LanguageList'
+import { PageList } from './PageList'
+import { MapList } from './MapList'
+import { TileList } from './TileList'
+import { DialogList } from './DialogList'
+import { StylingList } from './StylingList'
+import { HandlerList } from './HandlerList'
+import { VirtualKeyList } from './VirtualKeyList'
+import { VirtualInputList } from './VirtualInputList'
+import { useEditableList } from './useEditableList'
+
+interface GameFormProps {
+  game: Game
+  setGame: React.Dispatch<React.SetStateAction<Game>>
+  styling: string[]
+  setStyling: React.Dispatch<React.SetStateAction<string[]>>
+  openMapEditor: (id: string) => void
+  onSave: () => void
+  saving: boolean
+}
+
+export const GameForm: React.FC<GameFormProps> = ({
+  game,
+  setGame,
+  styling,
+  setStyling,
+  openMapEditor,
+  onSave,
+  saving,
+}) => {
+  const setLanguageMap = (
+    updater: React.SetStateAction<Record<string, string[]>>,
+  ) =>
+    setGame((g) => ({ ...g, languages: typeof updater === 'function' ? updater(g.languages) : updater }))
+
+  const setMap = <K extends 'pages' | 'maps' | 'tiles' | 'dialogs'>(key: K) =>
+    (updater: React.SetStateAction<Record<string, string>>) =>
+      setGame((g) => ({ ...g, [key]: typeof updater === 'function' ? updater(g[key]) : updater }))
+
+  const setArray = <K extends 'handlers' | 'virtualKeys' | 'virtualInputs'>(key: K) =>
+    (updater: React.SetStateAction<string[]>) =>
+      setGame((g) => ({ ...g, [key]: typeof updater === 'function' ? updater(g[key]) : updater }))
+
+  const languageActions = useEditableList<string[]>(setLanguageMap, {
+    type: 'map',
+    prefix: 'language',
+    empty: [],
+  })
+  const pageActions = useEditableList(setMap('pages'), {
+    type: 'map',
+    prefix: 'page',
+    empty: '',
+  })
+  const mapActions = useEditableList(setMap('maps'), {
+    type: 'map',
+    prefix: 'map',
+    empty: '',
+  })
+  const tileActions = useEditableList(setMap('tiles'), {
+    type: 'map',
+    prefix: 'tile',
+    empty: '',
+  })
+  const dialogActions = useEditableList(setMap('dialogs'), {
+    type: 'map',
+    prefix: 'dialog',
+    empty: '',
+  })
+  const stylingActions = useEditableList(setStyling, { type: 'array' })
+  const handlerActions = useEditableList(setArray('handlers'), {
+    type: 'array',
+  })
+  const virtualKeyActions = useEditableList(setArray('virtualKeys'), {
+    type: 'array',
+  })
+  const virtualInputActions = useEditableList(setArray('virtualInputs'), {
+    type: 'array',
+  })
+
+  return (
+    <>
+      <fieldset className="editor-section">
+        <label>
+          Title:
+          <input
+            type="text"
+            value={game.title}
+            onChange={(e) => setGame({ ...game, title: e.target.value })}
+          />
+        </label>
+        <label>
+          Description:
+          <textarea
+            value={game.description}
+            onChange={(e) => setGame({ ...game, description: e.target.value })}
+          />
+        </label>
+        <label>
+          Version:
+          <input
+            type="text"
+            value={game.version}
+            onChange={(e) => setGame({ ...game, version: e.target.value })}
+          />
+        </label>
+      </fieldset>
+      <fieldset className="editor-section">
+        <label>
+          Initial Language:
+          <input
+            type="text"
+            value={game.initialData.language}
+            onChange={(e) =>
+              setGame({
+                ...game,
+                initialData: { ...game.initialData, language: e.target.value },
+              })
+            }
+          />
+        </label>
+        <label>
+          Start Page:
+          <input
+            type="text"
+            value={game.initialData.startPage}
+            onChange={(e) =>
+              setGame({
+                ...game,
+                initialData: { ...game.initialData, startPage: e.target.value },
+              })
+            }
+          />
+        </label>
+      </fieldset>
+      <LanguageList languages={game.languages} {...languageActions} />
+      <PageList pages={game.pages} {...pageActions} />
+      <MapList maps={game.maps} onEdit={openMapEditor} {...mapActions} />
+      <TileList tiles={game.tiles} {...tileActions} />
+      <DialogList dialogs={game.dialogs} {...dialogActions} />
+      <StylingList styling={styling} {...stylingActions} />
+      <HandlerList handlers={game.handlers} {...handlerActions} />
+      <VirtualKeyList virtualKeys={game.virtualKeys} {...virtualKeyActions} />
+      <VirtualInputList
+        virtualInputs={game.virtualInputs}
+        {...virtualInputActions}
+      />
+      <button type="button" onClick={onSave} disabled={saving}>
+        Save
+      </button>
+    </>
+  )
+}

--- a/src/editor/components/MapEditorPanel.tsx
+++ b/src/editor/components/MapEditorPanel.tsx
@@ -1,0 +1,20 @@
+import type React from 'react'
+import type { GameMap } from '@loader/data/map'
+import type { Tile } from '@loader/data/tile'
+import { MapEditor } from './MapEditor'
+
+interface MapEditorPanelProps {
+  map: GameMap
+  tiles: Record<string, Tile>
+  onSave: (map: GameMap, tiles: Record<string, Tile>) => void
+  onCancel: () => void
+}
+
+export const MapEditorPanel: React.FC<MapEditorPanelProps> = ({
+  map,
+  tiles,
+  onSave,
+  onCancel,
+}) => (
+  <MapEditor map={map} tiles={tiles} onSave={onSave} onCancel={onCancel} />
+)

--- a/src/editor/hooks/useGameData.ts
+++ b/src/editor/hooks/useGameData.ts
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+import { gameSchema } from '@loader/schema/game'
+import type { Game } from '@loader/data/game'
+import { saveGame } from '../main'
+
+export interface UseGameDataResult {
+  game: Game | null
+  setGame: React.Dispatch<React.SetStateAction<Game | null>>
+  styling: string[]
+  setStyling: React.Dispatch<React.SetStateAction<string[]>>
+  statusMessage: string
+  setStatusMessage: React.Dispatch<React.SetStateAction<string>>
+  loadError: string
+  saving: boolean
+  save: () => Promise<void>
+}
+
+export function useGameData(): UseGameDataResult {
+  const [game, setGame] = useState<Game | null>(null)
+  const [styling, setStyling] = useState<string[]>([])
+  const [statusMessage, setStatusMessage] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [loadError, setLoadError] = useState('')
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const load = async () => {
+      try {
+        const response = await fetch('/api/game', {
+          signal: controller.signal,
+        })
+
+        if (!response.ok) {
+          setLoadError('Failed to load game data.')
+          setGame({
+            title: '',
+            description: '',
+            version: '',
+            initialData: { language: '', startPage: '' },
+            languages: {},
+            pages: {},
+            maps: {},
+            tiles: {},
+            dialogs: {},
+            handlers: [],
+            virtualKeys: [],
+            virtualInputs: [],
+          })
+          setStyling([])
+          return
+        }
+
+        const data = await response.json()
+        const parsed = gameSchema.parse(data)
+        const result: Game = {
+          title: parsed.title,
+          description: parsed.description,
+          version: parsed.version,
+          initialData: {
+            language: parsed['initial-data'].language,
+            startPage: parsed['initial-data']['start-page'],
+          },
+          languages: { ...parsed.languages },
+          pages: { ...parsed.pages },
+          maps: { ...parsed.maps },
+          tiles: { ...parsed.tiles },
+          dialogs: { ...parsed.dialogs },
+          handlers: [...parsed.handlers],
+          virtualKeys: [...parsed['virtual-keys']],
+          virtualInputs: [...parsed['virtual-inputs']],
+        }
+        setGame(result)
+        setStyling(parsed.styling)
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return
+        setLoadError('Failed to load game data.')
+        setGame({
+          title: '',
+          description: '',
+          version: '',
+          initialData: { language: '', startPage: '' },
+          languages: {},
+          pages: {},
+          maps: {},
+          dialogs: {},
+          tiles: {},
+          handlers: [],
+          virtualKeys: [],
+          virtualInputs: [],
+        })
+        setStyling([])
+      }
+    }
+
+    load()
+    return () => controller.abort()
+  }, [])
+
+  const save = async () => {
+    if (!game) return
+    const obj = {
+      title: game.title,
+      description: game.description,
+      version: game.version,
+      'initial-data': {
+        language: game.initialData.language,
+        'start-page': game.initialData.startPage,
+      },
+      languages: game.languages,
+      pages: game.pages,
+      maps: game.maps,
+      tiles: game.tiles,
+      dialogs: game.dialogs,
+      styling,
+      handlers: game.handlers,
+      'virtual-keys': game.virtualKeys,
+      'virtual-inputs': game.virtualInputs,
+    }
+    const json = JSON.stringify(obj, null, 2)
+    setSaving(true)
+    const message = await saveGame(json)
+    setStatusMessage(message)
+    setSaving(false)
+  }
+
+  return {
+    game,
+    setGame,
+    styling,
+    setStyling,
+    statusMessage,
+    setStatusMessage,
+    loadError,
+    saving,
+    save,
+  }
+}

--- a/src/editor/hooks/useGameTabs.ts
+++ b/src/editor/hooks/useGameTabs.ts
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import type { Game } from '@loader/data/game'
+import type { GameMap } from '@loader/data/map'
+import type { Tile } from '@loader/data/tile'
+import { resolveTileSet } from '../resolveTileSet'
+import { fromAnyMap, toSchemaMap } from '../convertMap'
+import { saveGame } from '../main'
+
+export interface UseGameTabsResult {
+  tab: 'game' | 'map'
+  setTab: React.Dispatch<React.SetStateAction<'game' | 'map'>>
+  editingMap: GameMap | null
+  editingTiles: Record<string, Tile>
+  openMapEditor: (id: string) => Promise<void>
+  handleMapSave: (map: GameMap, tiles: Record<string, Tile>) => Promise<void>
+}
+
+export function useGameTabs(
+  game: Game | null,
+  setStatusMessage: React.Dispatch<React.SetStateAction<string>>,
+): UseGameTabsResult {
+  const [tab, setTab] = useState<'game' | 'map'>('game')
+  const [editingMap, setEditingMap] = useState<GameMap | null>(null)
+  const [editingTiles, setEditingTiles] = useState<Record<string, Tile>>({})
+  const [editingMapId, setEditingMapId] = useState<string | null>(null)
+
+  const openMapEditor = async (id: string) => {
+    if (!game) return
+    const path = game.maps[id]
+    let mapData: GameMap
+    let tiles: Record<string, Tile> = {}
+    try {
+      const res = await fetch(`/api/map/${encodeURIComponent(path)}`)
+      if (!res.ok) throw new Error('failed')
+      const json = await res.json()
+      mapData = fromAnyMap(json)
+      await Promise.all(
+        (mapData.tileSets || []).map(async (setId: string) => {
+          const tilePath = game.tiles[setId]
+          if (!tilePath) return
+          const tRes = await fetch(`/api/map/${encodeURIComponent(tilePath)}`)
+          if (!tRes.ok) return
+          const tJson = await tRes.json()
+          if (Array.isArray(tJson.tiles)) {
+            Object.assign(tiles, resolveTileSet(tilePath, tJson.tiles as Tile[]))
+          }
+        }),
+      )
+    } catch {
+      mapData = {
+        key: id,
+        type: 'squares-map',
+        width: 1,
+        height: 1,
+        tileSets: [],
+        tiles: { blank: { key: 'blank', tile: 'blank' } },
+        map: [['blank']],
+      }
+      tiles = {
+        blank: { key: 'blank', description: '', color: 'transparent' },
+      }
+      setStatusMessage('Failed to load map')
+    }
+    setEditingMapId(id)
+    setEditingMap(mapData)
+    setEditingTiles(tiles)
+    setTab('map')
+  }
+
+  const handleMapSave = async (
+    map: GameMap,
+    tiles: Record<string, Tile>,
+  ) => {
+    if (!game || !editingMapId) return
+    const json = JSON.stringify({ map: toSchemaMap(map), tiles }, null, 2)
+    const path = game.maps[editingMapId]
+    const message = await saveGame(
+      json,
+      (_url, options) => fetch(`/api/map/${encodeURIComponent(path)}`, options),
+    )
+    setStatusMessage(message)
+    setTab('game')
+  }
+
+  return {
+    tab,
+    setTab,
+    editingMap,
+    editingTiles,
+    openMapEditor,
+    handleMapSave,
+  }
+}


### PR DESCRIPTION
## Summary
- add useGameData and useGameTabs hooks to manage game state and map tabs
- extract GameForm and MapEditorPanel UI components
- refactor GameEditor to compose new hooks and components

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689473ac26048332a168676fb9e05a25