### PR TITLE
refactor: centralize event listener cleanup

### DIFF
--- a/src/engine/common/eventHandlerManager.ts
+++ b/src/engine/common/eventHandlerManager.ts
@@ -1,0 +1,18 @@
+export interface IEventHandlerManager {
+    addListener(cleanupFn: () => void): void
+    clearListeners(): void
+}
+
+export class EventHandlerManager implements IEventHandlerManager {
+    private cleanupFns: (() => void)[] = []
+
+    public addListener(cleanupFn: () => void): void {
+        this.cleanupFns.push(cleanupFn)
+    }
+
+    public clearListeners(): void {
+        this.cleanupFns.forEach(fn => fn())
+        this.cleanupFns = []
+    }
+}
+

--- a/src/engine/input/inputManager.ts
+++ b/src/engine/input/inputManager.ts
@@ -3,6 +3,7 @@ import { VIRTUAL_INPUT_MESSAGE } from '../messages/messages'
 import type { Action } from '@loader/data/action'
 import { InputSourceTracker } from './inputSourceTracker'
 import { InputMatrixBuilder, type MatrixInputItem } from './inputMatrixBuilder'
+import { EventHandlerManager } from '@engine/common/eventHandlerManager'
 
 export type { MatrixInputItem } from './inputMatrixBuilder'
 export { nullMatrixInputItem } from './inputMatrixBuilder'
@@ -22,15 +23,15 @@ export type InputManagerServices = {
 }
 
 export class InputManager implements IInputManager {
-    private unregisterEventHandlers: (() => void)[] = []
     private services: InputManagerServices
+    private eventHandlerManager = new EventHandlerManager()
 
     constructor(services: InputManagerServices) {
         this.services = services
     }
 
     public initialize(): void {
-        this.unregisterEventHandlers.push(
+        this.eventHandlerManager.addListener(
             this.services.messageBus.registerMessageListener(
                 VIRTUAL_INPUT_MESSAGE,
                 (message) => this.onInput(message.payload as string)
@@ -39,8 +40,7 @@ export class InputManager implements IInputManager {
     }
 
     public cleanup(): void {
-        this.unregisterEventHandlers.forEach(unregister => unregister())
-        this.unregisterEventHandlers = []
+        this.eventHandlerManager.clearListeners()
     }
 
     public update(): void {

--- a/src/engine/output/outputManager.ts
+++ b/src/engine/output/outputManager.ts
@@ -1,5 +1,6 @@
 import type { IMessageBus } from '@utils/messageBus'
 import { ADD_LINE_TO_OUTPUT_LOG, OUTPUT_LOG_LINE_ADDED } from '../messages/messages'
+import { EventHandlerManager } from '@engine/common/eventHandlerManager'
 
 export interface IOutputManager {
     initialize(): void
@@ -13,7 +14,7 @@ export type OutputManagerServices = {
 
 export class OutputManager implements IOutputManager {
     private services: OutputManagerServices
-    private unregisterEventHandlers: (() => void)[] = []
+    private eventHandlerManager = new EventHandlerManager()
     private outputLogLines: string[] = []
     private currentMaxSize: number = 0
 
@@ -22,7 +23,7 @@ export class OutputManager implements IOutputManager {
     }
 
     public initialize(): void {
-        this.unregisterEventHandlers.push(
+        this.eventHandlerManager.addListener(
             this.services.messageBus.registerMessageListener(
                 ADD_LINE_TO_OUTPUT_LOG,
                 (message) => this.newLine(message.payload as string)
@@ -31,7 +32,7 @@ export class OutputManager implements IOutputManager {
     }
 
     public cleanup(): void {
-        this.unregisterEventHandlers.forEach(unregister => unregister())
+        this.eventHandlerManager.clearListeners()
         this.outputLogLines = []
     }
 

--- a/test/engine/eventHandlerManager.test.ts
+++ b/test/engine/eventHandlerManager.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+import { EventHandlerManager } from '@engine/common/eventHandlerManager'
+
+describe('EventHandlerManager', () => {
+  it('executes and clears registered listeners', () => {
+    const manager = new EventHandlerManager()
+    const fn1 = vi.fn()
+    const fn2 = vi.fn()
+
+    manager.addListener(fn1)
+    manager.addListener(fn2)
+
+    manager.clearListeners()
+    expect(fn1).toHaveBeenCalled()
+    expect(fn2).toHaveBeenCalled()
+
+    fn1.mockClear()
+    fn2.mockClear()
+    manager.clearListeners()
+    expect(fn1).not.toHaveBeenCalled()
+    expect(fn2).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add reusable EventHandlerManager for listener cleanup
- refactor managers to use helper
- cover EventHandlerManager with unit test

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68949aa501b8833291fd8fcb295c1bf5