### PR TITLE
feat: expose triggering messages to scripts

### DIFF
--- a/src/engine/actions/actionHandler.ts
+++ b/src/engine/actions/actionHandler.ts
@@ -1,8 +1,9 @@
 import type { Action } from '@loader/data/action'
 import type { IGameEngine } from '@engine/core/gameEngine'
+import type { Message } from '@utils/types'
 
 export interface IActionHandler {
     readonly type: Action['type']
-    handle(engine: IGameEngine, action: Action): void
+    handle(engine: IGameEngine, action: Action, message?: Message): void
 }
 

--- a/src/engine/actions/postMessageActionHandler.ts
+++ b/src/engine/actions/postMessageActionHandler.ts
@@ -1,11 +1,13 @@
 import type { IActionHandler } from './actionHandler'
 import type { Action, PostMessageAction } from '@loader/data/action'
 import type { IGameEngine } from '@engine/core/gameEngine'
+import type { Message } from '@utils/types'
 
 export class PostMessageActionHandler implements IActionHandler {
     readonly type = 'post-message' as const
 
-    handle(engine: IGameEngine, action: Action): void {
+    handle(engine: IGameEngine, action: Action, _message?: Message): void {
+        void _message
         const { message, payload } = action as PostMessageAction
         engine.MessageBus.postMessage({ message, payload })
     }

--- a/src/engine/actions/scriptActionHandler.ts
+++ b/src/engine/actions/scriptActionHandler.ts
@@ -1,13 +1,14 @@
 import type { IActionHandler } from './actionHandler'
 import type { Action, ScriptAction } from '@loader/data/action'
 import type { IGameEngine } from '@engine/core/gameEngine'
+import type { Message } from '@utils/types'
 
 export class ScriptActionHandler implements IActionHandler {
     readonly type = 'script' as const
 
-    handle(engine: IGameEngine, action: Action): void {
+    handle(engine: IGameEngine, action: Action, message?: Message): void {
         const { script } = action as ScriptAction
-        engine.ScriptRunner.run<void>(script, engine.createScriptContext())
+        engine.ScriptRunner.run<void>(script, engine.createScriptContext(message))
     }
 }
 

--- a/src/engine/conditions/scriptConditionResolver.ts
+++ b/src/engine/conditions/scriptConditionResolver.ts
@@ -7,7 +7,7 @@ export class ScriptConditionResolver implements IConditionResolver {
 
     resolve(engine: IGameEngine, condition: Condition): boolean {
         const { script } = condition as ScriptCondition
-        return engine.ScriptRunner.run<boolean>(script, engine.createScriptContext())
+        return engine.ScriptRunner.run<boolean>(script, engine.createScriptContext(undefined))
     }
 }
 

--- a/src/engine/core/gameEngine.ts
+++ b/src/engine/core/gameEngine.ts
@@ -23,7 +23,7 @@ export interface IGameEngine {
     resolveCondition(condition: Condition | null): boolean
     registerActionHandler(handler: IActionHandler): void
     registerConditionResolver(resolver: IConditionResolver): void
-    createScriptContext(): ScriptContext
+    createScriptContext(message?: Message): ScriptContext
     setIsLoading(): void
     setIsRunning(): void
     get StateManager(): IStateManager<ContextData>
@@ -78,7 +78,7 @@ export class GameEngine implements IGameEngine {
     }
 
     public executeAction(action: Action): void {
-        this.handlerRegistry.executeAction(this, action)
+        this.handlerRegistry.executeAction(this, action, undefined)
     }
 
     public resolveCondition(condition: Condition | null): boolean {
@@ -121,12 +121,14 @@ export class GameEngine implements IGameEngine {
         return this.outputManager
     }
 
-    public createScriptContext(): ScriptContext {
+    public createScriptContext(message?: Message): ScriptContext {
         const context: ScriptContext = {
             state: this.StateManager.state,
-            postMessage: (message: Message) => {
-                this.MessageBus.postMessage(message)
-            }
+            postMessage: (msg: Message) => {
+                this.MessageBus.postMessage(msg)
+            },
+            triggerMessage: message?.message,
+            triggerPayload: message?.payload
         }
         return context
     }

--- a/src/engine/core/gameEngineInitializer.ts
+++ b/src/engine/core/gameEngineInitializer.ts
@@ -22,6 +22,7 @@ import type { IActionHandler } from '../actions/actionHandler'
 import type { IConditionResolver } from '../conditions/conditionResolver'
 import type { Action } from '@loader/data/action'
 import type { Condition } from '@loader/data/condition'
+import type { Message } from '@utils/types'
 import { TurnScheduler } from './turnScheduler'
 import { GameEngine } from './gameEngine'
 import { HandlerRegistry, type IHandlerRegistry } from './handlerRegistry'
@@ -42,7 +43,7 @@ export interface IEngineManagerFactory {
         stateManager: IStateManager<ContextData>,
         mapLoader: IMapLoader,
         tileLoader: ITileLoader,
-        executeAction: (action: Action) => void,
+        executeAction: (action: Action, message?: Message) => void,
         setIsLoading: () => void,
         setIsRunning: () => void
     ): IMapManager
@@ -56,7 +57,7 @@ export interface IEngineManagerFactory {
         stateManager: IStateManager<ContextData>,
         translationService: ITranslationService,
         virtualInputHandler: IVirtualInputHandler,
-        executeAction: (action: Action) => void,
+        executeAction: (action: Action, message?: Message) => void,
         resolveCondition: (condition: Condition | null) => boolean
     ): IInputManager
     createOutputManager(messageBus: IMessageBus): IOutputManager
@@ -118,7 +119,7 @@ export class GameEngineInitializer {
 
         const setIsLoading = () => stateController.setIsLoading()
         const setIsRunning = () => stateController.setIsRunning()
-        const executeAction = (action: Action) => handlerRegistry.executeAction(engine, action)
+        const executeAction = (action: Action, message?: Message) => handlerRegistry.executeAction(engine, action, message)
         const resolveCondition = (condition: Condition | null) => handlerRegistry.resolveCondition(engine, condition)
 
         const pageManager = factory.createPageManager(messageBus, stateManager, loader.pageLoader, setIsLoading, setIsRunning)

--- a/src/engine/input/inputManager.ts
+++ b/src/engine/input/inputManager.ts
@@ -1,6 +1,7 @@
 import type { IMessageBus } from '@utils/messageBus'
 import { VIRTUAL_INPUT_MESSAGE } from '../messages/messages'
 import type { Action } from '@loader/data/action'
+import type { Message } from '@utils/types'
 import { InputSourceTracker } from './inputSourceTracker'
 import { InputMatrixBuilder, type MatrixInputItem } from './inputMatrixBuilder'
 import { EventHandlerManager } from '@engine/common/eventHandlerManager'
@@ -19,7 +20,7 @@ export type InputManagerServices = {
     messageBus: IMessageBus
     inputSourceTracker: InputSourceTracker
     inputMatrixBuilder: InputMatrixBuilder
-    executeAction: (action: Action) => void
+    executeAction: (action: Action, message?: Message) => void
 }
 
 export class InputManager implements IInputManager {
@@ -55,7 +56,7 @@ export class InputManager implements IInputManager {
     private onInput(input: string): void {
         const inputItem = this.services.inputSourceTracker.getInput(input)
         if (inputItem && inputItem.enabled && inputItem.input.action) {
-            this.services.executeAction(inputItem.input.action)
+            this.services.executeAction(inputItem.input.action, undefined)
         }
     }
 }

--- a/src/engine/input/inputManagerService.ts
+++ b/src/engine/input/inputManagerService.ts
@@ -3,6 +3,7 @@ import { InputSourceTracker } from './inputSourceTracker'
 import { InputMatrixBuilder } from './inputMatrixBuilder'
 import type { Action } from '@loader/data/action'
 import type { Condition } from '@loader/data/condition'
+import type { Message } from '@utils/types'
 import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
 import type { IMessageBus } from '@utils/messageBus'
@@ -14,7 +15,7 @@ export function createInputManager(
     stateManager: IStateManager<ContextData>,
     translationService: ITranslationService,
     virtualInputHandler: IVirtualInputHandler,
-    executeAction: (action: Action) => void,
+    executeAction: (action: Action, message?: Message) => void,
     resolveCondition: (condition: Condition | null) => boolean
 ): IInputManager {
     const inputSourceTracker = new InputSourceTracker({

--- a/src/engine/map/mapManager.ts
+++ b/src/engine/map/mapManager.ts
@@ -5,6 +5,7 @@ import type { ContextData } from '../core/context'
 import { CHANGE_POSITION_MESSAGE, POSITION_CHANGED_MESSAGE } from '../messages/messages'
 import type { ChangePositionPayload } from '@engine/messages/types'
 import type { Action } from '@loader/data/action'
+import type { Message } from '@utils/types'
 import type { IMapLoaderService } from './mapLoaderService'
 import { EventHandlerManager } from '@engine/common/eventHandlerManager'
 
@@ -16,7 +17,7 @@ export interface IMapManager {
 export type MapManagerServices = {
     messageBus: IMessageBus
     stateManager: IStateManager<ContextData>
-    executeAction: (action: Action) => void
+    executeAction: (action: Action, message?: Message) => void
     mapLoaderService: IMapLoaderService
 }
 
@@ -58,7 +59,7 @@ export class MapManager implements IMapManager {
         })
         logDebug('MapManager', 'Position set to x: {0}, y: {1}', position.x, position.y)
         if (tile.onEnter) {
-            this.services.executeAction(tile.onEnter)
+            this.services.executeAction(tile.onEnter, undefined)
         }
     }
 }

--- a/src/engine/map/mapManagerService.ts
+++ b/src/engine/map/mapManagerService.ts
@@ -3,6 +3,7 @@ import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
 import type { IMessageBus } from '@utils/messageBus'
 import type { Action } from '@loader/data/action'
+import type { Message } from '@utils/types'
 import type { IMapLoader } from '@loader/mapLoader'
 import type { ITileLoader } from '@loader/tileLoader'
 import { MapLoaderService, type MapLoaderServiceDependencies } from './mapLoaderService'
@@ -12,7 +13,7 @@ export function createMapManager(
     stateManager: IStateManager<ContextData>,
     mapLoader: IMapLoader,
     tileLoader: ITileLoader,
-    executeAction: (action: Action) => void,
+    executeAction: (action: Action, message?: Message) => void,
     setIsLoading: () => void,
     setIsRunning: () => void
 ): IMapManager {

--- a/src/engine/script/scriptRunner.ts
+++ b/src/engine/script/scriptRunner.ts
@@ -8,7 +8,9 @@ export interface IScriptRunner {
 
 export type ScriptContext = {
     state: ContextData,
-    postMessage: (message: Message) => void
+    postMessage: (message: Message) => void,
+    triggerMessage?: string,
+    triggerPayload?: Message['payload']
 }
 
 export class ScriptRunner implements IScriptRunner {

--- a/test/engine/inputManager.test.ts
+++ b/test/engine/inputManager.test.ts
@@ -68,7 +68,7 @@ function createInputManager(actionFn = vi.fn()) {
     messageBus: messageBus as any,
     inputSourceTracker,
     inputMatrixBuilder,
-    executeAction: actionFn
+    executeAction: actionFn as any
   }
 
   const inputManager = new InputManager(services)

--- a/test/engine/scriptActionHandler.test.ts
+++ b/test/engine/scriptActionHandler.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { ScriptActionHandler } from '@engine/actions/scriptActionHandler'
+import { HandlerRegistry } from '@engine/core/handlerRegistry'
+import { GameEngine } from '@engine/core/gameEngine'
+import { ScriptRunner } from '@engine/script/scriptRunner'
+import type { EngineContext } from '@engine/core/engineContext'
+import type { Message, CleanUp } from '@utils/types'
+import type { Action, ScriptAction } from '@loader/data/action'
+
+function createEngine() {
+  const handlers: Record<string, ((msg: Message) => void)[]> = {}
+  const messageBus = {
+    registerMessageListener: (message: string, handler: (msg: Message) => void): CleanUp => {
+      handlers[message] ??= []
+      handlers[message].push(handler)
+      return () => {
+        const list = handlers[message]
+        if (list) {
+          const index = list.indexOf(handler)
+          if (index >= 0) list.splice(index, 1)
+        }
+      }
+    },
+    postMessage: (message: Message) => {
+      handlers[message.message]?.forEach(h => h(message))
+    },
+    registerNotificationMessage: () => {},
+    shutDown: () => {}
+  }
+  const stateManager = { state: { data: {} } } as any
+  const handlerRegistry = new HandlerRegistry()
+  const engineContext: EngineContext = {
+    messageBus: messageBus as any,
+    stateManager,
+    translationService: {} as any,
+    inputManager: {} as any,
+    outputManager: {} as any,
+    scriptRunner: new ScriptRunner(),
+    lifecycleManager: {} as any,
+    handlerRegistry,
+    stateController: { State: { value: 0 }, setIsLoading: () => {}, setIsRunning: () => {} } as any
+  }
+  const engine = new GameEngine(engineContext)
+  handlerRegistry.registerActionHandler(new ScriptActionHandler())
+  return { engine, handlerRegistry, messageBus }
+}
+
+describe('ScriptActionHandler', () => {
+  it('provides triggering message and payload to script context', () => {
+    const { engine, handlerRegistry, messageBus } = createEngine()
+    let result: any = null
+    messageBus.registerMessageListener('RESULT', msg => { result = msg.payload })
+    const action: ScriptAction = {
+      type: 'script',
+      script: "context.postMessage({ message: 'RESULT', payload: { msg: context.triggerMessage, payload: context.triggerPayload } })"
+    }
+    messageBus.registerMessageListener('TRIGGER', msg => {
+      handlerRegistry.executeAction(engine, action as Action, msg)
+    })
+    messageBus.postMessage({ message: 'TRIGGER', payload: { foo: 42 } })
+    expect(result).toEqual({ msg: 'TRIGGER', payload: { foo: 42 } })
+  })
+})


### PR DESCRIPTION
## Summary
- extend script context with triggerMessage and triggerPayload
- propagate optional Message through handler registry and action handlers
- add test ensuring scripts triggered by bus messages receive trigger data

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6894df12da108332a8e9140e2b0008f7