### PR TITLE
Fix schema map tile conversion to data format

### DIFF
--- a/src/editor/convertMap.ts
+++ b/src/editor/convertMap.ts
@@ -1,5 +1,6 @@
 import type { GameMap as DataGameMap, MapTile as DataMapTile } from '@loader/data/map'
 import type { SquaresMap as SchemaSquaresMap } from '@loader/schema/map'
+import { mapMapTile } from '@loader/mappers/map'
 
 export function toSchemaMap(map: DataGameMap): SchemaSquaresMap {
   return {
@@ -30,7 +31,7 @@ export function fromAnyMap(map: SchemaSquaresMap | DataGameMap): DataGameMap {
   const schema = map as SchemaSquaresMap
   const tilesRecord: Record<string, DataMapTile> = {}
   schema.tiles.forEach((t) => {
-    tilesRecord[t.key] = t
+    tilesRecord[t.key] = mapMapTile(t)
   })
   return {
     key: schema.key,

--- a/src/loader/mappers/map.ts
+++ b/src/loader/mappers/map.ts
@@ -1,5 +1,6 @@
 import type { GameMap as GameMapData, MapTile as MapTileData } from '@loader/data/map'
 import { type GameMap, type MapTile } from '@loader/schema/map'
+import { mapAction } from './action'
 
 
 export function mapGameMap(gameMap: GameMap): GameMapData {
@@ -21,7 +22,7 @@ export function mapMapTile(mapTile: MapTile): MapTileData {
     return {
         key: mapTile.key,
         tile: mapTile.tile,
-        onEnter: mapTile.onEnter
+        onEnter: mapTile.onEnter ? mapAction(mapTile.onEnter) : undefined
     }
 }
 


### PR DESCRIPTION
## Summary
- convert schema map tiles to data tiles in the editor using `mapMapTile`
- normalize `onEnter` actions with `mapAction` when mapping tiles

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6894ff0fabd08332bad8e08c036712dd