### PR TITLE
Validate game payload in server API

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -4,6 +4,7 @@ import express from 'express'
 import fs from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
+import { gameSchema } from '../loader/schema/game.ts'
 
 export function createApp(fsModule = fs) {
   const app = express()
@@ -29,6 +30,11 @@ export function createApp(fsModule = fs) {
   })
 
   app.post('/api/game', (req, res) => {
+    const parsed = gameSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json(parsed.error.issues)
+      return
+    }
     const jsonString = JSON.stringify(req.body, null, 2)
     fsModule.writeFile(gamePath, jsonString, 'utf-8', (err) => {
       if (err) {


### PR DESCRIPTION
## Summary
- validate /api/game request body with shared Zod schema
- test server rejects invalid game payload and updates tests to send valid data

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6895d9e9ea108332b37e815514055a08