### PR TITLE
feat(editor): add game tree component

### DIFF
--- a/src/editor/components/GameTree.tsx
+++ b/src/editor/components/GameTree.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import type { JSX } from 'react'
+import type { Game } from '../data/game'
+import { fetchGame } from '../services/api'
+
+export type NodePath = string[]
+
+export interface GameTreeViewProps {
+  game: Game
+  onSelect: (path: NodePath) => void
+}
+
+function renderRecord(
+  record: Record<string, unknown>,
+  path: NodePath,
+  onSelect: (p: NodePath) => void,
+): JSX.Element {
+  return (
+    <ul>
+      {Object.entries(record).map(([key, value]) => (
+        <li key={key}>
+          <button type="button" onClick={() => onSelect([...path, key])}>
+            {key}
+          </button>
+          {renderValue(value, [...path, key], onSelect)}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function renderArray(
+  arr: unknown[],
+  path: NodePath,
+  onSelect: (p: NodePath) => void,
+): JSX.Element {
+  return (
+    <ul>
+      {arr.map((value, index) => {
+        const label = typeof value === 'string' ? value : String(index)
+        const nextPath = [...path, label]
+        return (
+          <li key={label}>
+            <button type="button" onClick={() => onSelect(nextPath)}>
+              {label}
+            </button>
+            {renderValue(value, nextPath, onSelect)}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function renderValue(
+  value: unknown,
+  path: NodePath,
+  onSelect: (p: NodePath) => void,
+): JSX.Element | null {
+  if (Array.isArray(value)) {
+    return renderArray(value, path, onSelect)
+  }
+  if (typeof value === 'object' && value !== null) {
+    return renderRecord(value as Record<string, unknown>, path, onSelect)
+  }
+  return null
+}
+
+export const GameTreeView: React.FC<GameTreeViewProps> = ({ game, onSelect }) => {
+  const root: Record<string, unknown> = {
+    pages: game.pages,
+    maps: game.maps,
+    tiles: game.tiles,
+    dialogs: game.dialogs,
+    handlers: game.handlers,
+    virtualKeys: game.virtualKeys,
+    virtualInputs: game.virtualInputs,
+    languages: game.languages,
+  }
+  return renderRecord(root, [], onSelect)
+}
+
+export interface GameTreeProps {
+  onSelect: (path: NodePath) => void
+  fetchFn?: typeof fetchGame
+}
+
+export const GameTree: React.FC<GameTreeProps> = ({ onSelect, fetchFn = fetchGame }) => {
+  const [game, setGame] = useState<Game | null>(null)
+  const [error, setError] = useState<string>('')
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchFn(controller.signal)
+      .then((data) => setGame(data.game))
+      .catch((err: Error) => setError(err.message))
+    return () => controller.abort()
+  }, [fetchFn])
+
+  if (error) {
+    return <div>{error}</div>
+  }
+  if (!game) {
+    return <div>Loading...</div>
+  }
+  return <GameTreeView game={game} onSelect={onSelect} />
+}
+
+export default GameTree
+

--- a/test/editor/gameTree.test.tsx
+++ b/test/editor/gameTree.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { GameTreeView } from '@editor/components/GameTree'
+import type { Game } from '@editor/data/game'
+
+// React requires this flag for `act` in testing environments
+const reactEnv = globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+reactEnv.IS_REACT_ACT_ENVIRONMENT = true
+
+const sampleGame: Game = {
+  title: '',
+  description: '',
+  version: '',
+  initialData: { language: 'en', startPage: 'start' },
+  languages: { en: ['hello'] },
+  pages: { start: 'start.json' },
+  maps: { world: 'world.json' },
+  tiles: { grass: 'grass.json' },
+  dialogs: { intro: 'intro.json' },
+  handlers: ['handleStart'],
+  virtualKeys: ['A'],
+  virtualInputs: ['jump'],
+}
+
+describe('GameTreeView', () => {
+  it('renders game categories and items', () => {
+    const onSelect = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    act(() => {
+      root.render(<GameTreeView game={sampleGame} onSelect={onSelect} />)
+    })
+    const buttons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent)
+    expect(buttons).toContain('pages')
+    expect(buttons).toContain('start')
+    expect(buttons).toContain('maps')
+    expect(buttons).toContain('world')
+  })
+
+  it('emits node path on selection', () => {
+    const onSelect = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    act(() => {
+      root.render(<GameTreeView game={sampleGame} onSelect={onSelect} />)
+    })
+    const startButton = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'start',
+    ) as HTMLButtonElement
+    act(() => {
+      startButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onSelect).toHaveBeenCalledWith(['pages', 'start'])
+  })
+})
+


### PR DESCRIPTION
## Summary
- render game data as selectable tree in editor
- load game data via fetchGame
- test tree rendering and selection

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e0d368d88332bb8b8fd8ea9bd56c