### PR TITLE
feat(editor): add node detail editing

### DIFF
--- a/src/editor/components/NodeDetails.tsx
+++ b/src/editor/components/NodeDetails.tsx
@@ -1,0 +1,103 @@
+import type { ChangeEvent, FC } from 'react'
+import { useEditorContext } from '@editor/context/EditorContext'
+
+interface PageData {
+  title?: string
+  description?: string
+}
+
+interface MapData {
+  width?: number
+  height?: number
+}
+
+export const NodeDetails: FC = () => {
+  const { game, selectedPath, setGame } = useEditorContext()
+
+  if (!game || selectedPath.length < 2) {
+    return <div>Select a node</div>
+  }
+
+  const [category, id] = selectedPath
+
+  if (category === 'pages') {
+    const pageRecord = game.pages as unknown as Record<string, PageData>
+    const page = pageRecord[id] ?? { title: '', description: '' }
+
+    const handleChange = (field: 'title' | 'description') => (
+      e: ChangeEvent<HTMLInputElement>,
+    ) => {
+      const value = e.target.value
+      setGame({
+        ...game,
+        pages: {
+          ...game.pages,
+          [id]: { ...page, [field]: value },
+        },
+      })
+    }
+
+    return (
+      <form>
+        <label>
+          Title:
+          <input name="title" value={page.title ?? ''} onChange={handleChange('title')} />
+        </label>
+        <label>
+          Description:
+          <input
+            name="description"
+            value={page.description ?? ''}
+            onChange={handleChange('description')}
+          />
+        </label>
+      </form>
+    )
+  }
+
+  if (category === 'maps') {
+    const mapRecord = game.maps as unknown as Record<string, MapData>
+    const map = mapRecord[id] ?? { width: 0, height: 0 }
+
+    const handleChange = (field: 'width' | 'height') => (
+      e: ChangeEvent<HTMLInputElement>,
+    ) => {
+      const value = parseInt(e.target.value, 10) || 0
+      setGame({
+        ...game,
+        maps: {
+          ...game.maps,
+          [id]: { ...map, [field]: value },
+        },
+      })
+    }
+
+    return (
+      <form>
+        <label>
+          Width:
+          <input
+            name="width"
+            type="number"
+            value={map.width ?? 0}
+            onChange={handleChange('width')}
+          />
+        </label>
+        <label>
+          Height:
+          <input
+            name="height"
+            type="number"
+            value={map.height ?? 0}
+            onChange={handleChange('height')}
+          />
+        </label>
+      </form>
+    )
+  }
+
+  return <div>Unsupported node type</div>
+}
+
+export default NodeDetails
+

--- a/src/editor/context/EditorContext.tsx
+++ b/src/editor/context/EditorContext.tsx
@@ -9,6 +9,7 @@ interface EditorContextValue {
   game: Game | null
   selectedPath: NodePath
   setSelectedPath: (path: NodePath) => void
+  setGame: (game: Game) => void
 }
 
 const EditorContext = createContext<EditorContextValue | undefined>(undefined)
@@ -22,19 +23,21 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
   children,
   fetchGameFn = fetchGame,
 }) => {
-  const [game, setGame] = useState<Game | null>(null)
+  const [game, setGameState] = useState<Game | null>(null)
   const [selectedPath, setSelectedPath] = useState<NodePath>([])
 
   useEffect(() => {
     const controller = new AbortController()
     fetchGameFn(controller.signal)
-      .then((data) => setGame(data.game))
-      .catch(() => setGame(null))
+      .then((data) => setGameState(data.game))
+      .catch(() => setGameState(null))
     return () => controller.abort()
   }, [fetchGameFn])
 
   return (
-    <EditorContext.Provider value={{ game, selectedPath, setSelectedPath }}>
+    <EditorContext.Provider
+      value={{ game, selectedPath, setSelectedPath, setGame: (g) => setGameState(g) }}
+    >
       {children}
     </EditorContext.Provider>
   )

--- a/src/editor/data/game.ts
+++ b/src/editor/data/game.ts
@@ -9,8 +9,8 @@ export interface Game {
   version: string
   initialData: InitialData
   languages: Record<string, string[]>
-  pages: Record<string, string>
-  maps: Record<string, string>
+  pages: Record<string, unknown>
+  maps: Record<string, unknown>
   tiles: Record<string, string>
   dialogs: Record<string, string>
   handlers: string[]

--- a/test/editor/nodeDetails.test.tsx
+++ b/test/editor/nodeDetails.test.tsx
@@ -1,0 +1,57 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import NodeDetails from '@editor/components/NodeDetails'
+import EditorContext from '@editor/context/EditorContext'
+import type { Game } from '@editor/data/game'
+import type { NodePath } from '@editor/context/EditorContext'
+
+// React requires this flag for `act` in testing environments
+const reactEnv = globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+reactEnv.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('NodeDetails', () => {
+  it('renders fields for page node', () => {
+    const sampleGame = {
+      title: '',
+      description: '',
+      version: '',
+      initialData: { language: 'en', startPage: 'start' },
+      languages: { en: ['hello'] },
+      pages: { start: { title: 'Start', description: 'Welcome' } },
+      maps: {},
+      tiles: {},
+      dialogs: {},
+      handlers: [],
+      virtualKeys: [],
+      virtualInputs: [],
+    } as unknown as Game
+
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['pages', 'start'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const titleInput = container.querySelector('input[name="title"]') as HTMLInputElement
+    const descInput = container.querySelector('input[name="description"]') as HTMLInputElement
+
+    expect(titleInput.value).toBe('Start')
+    expect(descInput.value).toBe('Welcome')
+  })
+})
+


### PR DESCRIPTION
## Summary
- allow EditorContext to update game data
- add NodeDetails component with fields for pages and maps
- test page detail rendering

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6895f1341a4083328e2575af2e006f76