### PR TITLE
feat(editor): extend node details

### DIFF
--- a/src/editor/components/NodeDetails.tsx
+++ b/src/editor/components/NodeDetails.tsx
@@ -11,6 +11,13 @@ interface MapData {
   height?: number
 }
 
+type TileData = string
+type DialogData = string
+type HandlerData = string
+type VirtualKeyData = string
+type VirtualInputData = string
+type LanguageData = string[]
+
 export const NodeDetails: FC = () => {
   const { game, selectedPath, setGame } = useEditorContext()
 
@@ -90,6 +97,114 @@ export const NodeDetails: FC = () => {
             type="number"
             value={map.height ?? 0}
             onChange={handleChange('height')}
+          />
+        </label>
+      </form>
+    )
+  }
+
+  if (category === 'tiles') {
+    const tileRecord = game.tiles as unknown as Record<string, TileData>
+    const tile = tileRecord[id] ?? ''
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setGame({
+        ...game,
+        tiles: {
+          ...game.tiles,
+          [id]: value,
+        },
+      })
+    }
+
+    return (
+      <form>
+        <label>
+          Value:
+          <input name="value" value={tile} onChange={handleChange} />
+        </label>
+      </form>
+    )
+  }
+
+  if (category === 'dialogs') {
+    const dialogRecord = game.dialogs as unknown as Record<string, DialogData>
+    const dialog = dialogRecord[id] ?? ''
+
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value
+      setGame({
+        ...game,
+        dialogs: {
+          ...game.dialogs,
+          [id]: value,
+        },
+      })
+    }
+
+    return (
+      <form>
+        <label>
+          Dialog:
+          <textarea name="text" value={dialog} onChange={handleChange} />
+        </label>
+      </form>
+    )
+  }
+
+  if (category === 'handlers' || category === 'virtualKeys' || category === 'virtualInputs') {
+    const listRecord = game as unknown as Record<
+      string,
+      (HandlerData | VirtualKeyData | VirtualInputData)[]
+    >
+    const list = listRecord[category] as (HandlerData | VirtualKeyData | VirtualInputData)[]
+    const index = list.indexOf(id as string)
+    const item = list[index] ?? ''
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      const newList = [...list]
+      newList[index] = value
+      setGame({
+        ...game,
+        [category]: newList,
+      } as unknown as typeof game)
+    }
+
+    return (
+      <form>
+        <label>
+          Value:
+          <input name="value" value={item} onChange={handleChange} />
+        </label>
+      </form>
+    )
+  }
+
+  if (category === 'languages') {
+    const langRecord = game.languages as unknown as Record<string, LanguageData>
+    const lines = langRecord[id] ?? []
+
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value.split('\n')
+      setGame({
+        ...game,
+        languages: {
+          ...game.languages,
+          [id]: value,
+        },
+      })
+    }
+
+    return (
+      <form>
+        <label>
+          Lines:
+          <textarea
+            name="lines"
+            value={lines.join('\n')}
+            onChange={handleChange}
           />
         </label>
       </form>

--- a/test/editor/nodeDetails.test.tsx
+++ b/test/editor/nodeDetails.test.tsx
@@ -11,22 +11,27 @@ import type { NodePath } from '@editor/context/EditorContext'
 const reactEnv = globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 reactEnv.IS_REACT_ACT_ENVIRONMENT = true
 
+function createGame(): Game {
+  return {
+    title: '',
+    description: '',
+    version: '',
+    initialData: { language: 'en', startPage: 'start' },
+    languages: { en: ['hello'] },
+    pages: {},
+    maps: {},
+    tiles: {},
+    dialogs: {},
+    handlers: [],
+    virtualKeys: [],
+    virtualInputs: [],
+  } as unknown as Game
+}
+
 describe('NodeDetails', () => {
   it('renders fields for page node', () => {
-    const sampleGame = {
-      title: '',
-      description: '',
-      version: '',
-      initialData: { language: 'en', startPage: 'start' },
-      languages: { en: ['hello'] },
-      pages: { start: { title: 'Start', description: 'Welcome' } },
-      maps: {},
-      tiles: {},
-      dialogs: {},
-      handlers: [],
-      virtualKeys: [],
-      virtualInputs: [],
-    } as unknown as Game
+    const sampleGame = createGame()
+    sampleGame.pages = { start: { title: 'Start', description: 'Welcome' } }
 
     const contextValue = {
       game: sampleGame,
@@ -52,6 +57,163 @@ describe('NodeDetails', () => {
 
     expect(titleInput.value).toBe('Start')
     expect(descInput.value).toBe('Welcome')
+  })
+
+  it('renders and updates tile node', () => {
+    const sampleGame = createGame()
+    sampleGame.tiles = { grass: '#' }
+
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['tiles', 'grass'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const valueInput = container.querySelector('input[name="value"]') as HTMLInputElement
+    expect(valueInput.value).toBe('#')
+  })
+
+  it('renders and updates dialog node', () => {
+    const sampleGame = createGame()
+    sampleGame.dialogs = { greet: 'Hello' }
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['dialogs', 'greet'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const textArea = container.querySelector('textarea[name="text"]') as HTMLTextAreaElement
+    expect(textArea.value).toBe('Hello')
+  })
+
+  it('renders and updates handler node', () => {
+    const sampleGame = createGame()
+    sampleGame.handlers = ['start']
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['handlers', 'start'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const valueInput = container.querySelector('input[name="value"]') as HTMLInputElement
+    expect(valueInput.value).toBe('start')
+  })
+
+  it('renders and updates virtual key node', () => {
+    const sampleGame = createGame()
+    sampleGame.virtualKeys = ['A']
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['virtualKeys', 'A'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const valueInput = container.querySelector('input[name="value"]') as HTMLInputElement
+    expect(valueInput.value).toBe('A')
+  })
+
+  it('renders and updates virtual input node', () => {
+    const sampleGame = createGame()
+    sampleGame.virtualInputs = ['jump']
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['virtualInputs', 'jump'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const valueInput = container.querySelector('input[name="value"]') as HTMLInputElement
+    expect(valueInput.value).toBe('jump')
+  })
+
+  it('renders and updates language node', () => {
+    const sampleGame = createGame()
+    sampleGame.languages = { en: ['hello', 'world'] }
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['languages', 'en'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const textArea = container.querySelector('textarea[name="lines"]') as HTMLTextAreaElement
+    expect(textArea.value).toBe('hello\nworld')
   })
 })
 


### PR DESCRIPTION
## Summary
- support tiles, dialogs, handlers, virtual keys, virtual inputs, and languages in NodeDetails
- define simple data shapes and form fields for each category
- add coverage in NodeDetails tests for the new categories

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895fb93882083329911a67b17ee199b