### PR TITLE
feat(editor): add root node for game settings

### DIFF
--- a/editor/README.md
+++ b/editor/README.md
@@ -20,3 +20,4 @@ This command serves the editor on [http://localhost:5174/editor.html](http://loc
 The editor maintains its own TypeScript definition for game data. Import the `Game` interface from `@editor/data/game`
 when extending editor features to ensure type safety.
 
+The tree view includes a top-level `game` node. Selecting this node lets you edit global settings such as the game title and description.

--- a/src/editor/components/GameTree.tsx
+++ b/src/editor/components/GameTree.tsx
@@ -91,14 +91,16 @@ export const GameTreeView: React.FC<GameTreeViewProps> = ({
   onSelect,
 }) => {
   const root: Record<string, unknown> = {
-    pages: game.pages,
-    maps: game.maps,
-    tiles: game.tiles,
-    dialogs: game.dialogs,
-    handlers: game.handlers,
-    virtualKeys: game.virtualKeys,
-    virtualInputs: game.virtualInputs,
-    languages: game.languages,
+    game: {
+      pages: game.pages,
+      maps: game.maps,
+      tiles: game.tiles,
+      dialogs: game.dialogs,
+      handlers: game.handlers,
+      virtualKeys: game.virtualKeys,
+      virtualInputs: game.virtualInputs,
+      languages: game.languages,
+    },
   }
   return renderRecord(root, [], onSelect, selectedPath)
 }

--- a/src/editor/components/NodeDetails.tsx
+++ b/src/editor/components/NodeDetails.tsx
@@ -21,11 +21,46 @@ type LanguageData = string[]
 export const NodeDetails: FC = () => {
   const { game, selectedPath, setGame } = useEditorContext()
 
-  if (!game || selectedPath.length < 2) {
+  if (!game) {
     return <div>Select a node</div>
   }
 
-  const [category, id] = selectedPath
+  const path = selectedPath[0] === 'game' ? selectedPath.slice(1) : selectedPath
+
+  if (path.length === 0) {
+    const handleChange = (field: 'title' | 'description') => (
+      e: ChangeEvent<HTMLInputElement>,
+    ) => {
+      const value = e.target.value
+      setGame({
+        ...game,
+        [field]: value,
+      })
+    }
+
+    return (
+      <form>
+        <label>
+          Title:
+          <input name="title" value={game.title} onChange={handleChange('title')} />
+        </label>
+        <label>
+          Description:
+          <input
+            name="description"
+            value={game.description}
+            onChange={handleChange('description')}
+          />
+        </label>
+      </form>
+    )
+  }
+
+  if (path.length < 2) {
+    return <div>Select a node</div>
+  }
+
+  const [category, id] = path
 
   if (category === 'pages') {
     const pageRecord = game.pages as unknown as Record<string, PageData>

--- a/test/editor/gameTree.test.tsx
+++ b/test/editor/gameTree.test.tsx
@@ -36,6 +36,7 @@ describe('GameTreeView', () => {
       )
     })
     const buttons = Array.from(container.querySelectorAll('button')).map((b) => b.textContent)
+    expect(buttons).toContain('game')
     expect(buttons).toContain('pages')
     expect(buttons).toContain('start')
     expect(buttons).toContain('maps')
@@ -58,7 +59,7 @@ describe('GameTreeView', () => {
     act(() => {
       startButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
-    expect(onSelect).toHaveBeenCalledWith(['pages', 'start'])
+    expect(onSelect).toHaveBeenCalledWith(['game', 'pages', 'start'])
   })
 })
 

--- a/test/editor/nodeDetails.test.tsx
+++ b/test/editor/nodeDetails.test.tsx
@@ -29,13 +29,44 @@ function createGame(): Game {
 }
 
 describe('NodeDetails', () => {
+  it('renders game settings for root node', () => {
+    const sampleGame = createGame()
+    sampleGame.title = 'My Game'
+    sampleGame.description = 'Demo'
+
+    const contextValue = {
+      game: sampleGame,
+      selectedPath: ['game'] as NodePath,
+      setSelectedPath: vi.fn(),
+      setGame: vi.fn(),
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <EditorContext.Provider value={contextValue}>
+          <NodeDetails />
+        </EditorContext.Provider>,
+      )
+    })
+
+    const titleInput = container.querySelector('input[name="title"]') as HTMLInputElement
+    const descInput = container.querySelector('input[name="description"]') as HTMLInputElement
+
+    expect(titleInput.value).toBe('My Game')
+    expect(descInput.value).toBe('Demo')
+  })
+
   it('renders fields for page node', () => {
     const sampleGame = createGame()
     sampleGame.pages = { start: { title: 'Start', description: 'Welcome' } }
 
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['pages', 'start'] as NodePath,
+      selectedPath: ['game', 'pages', 'start'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }
@@ -65,7 +96,7 @@ describe('NodeDetails', () => {
 
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['tiles', 'grass'] as NodePath,
+      selectedPath: ['game', 'tiles', 'grass'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }
@@ -91,7 +122,7 @@ describe('NodeDetails', () => {
     sampleGame.dialogs = { greet: 'Hello' }
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['dialogs', 'greet'] as NodePath,
+      selectedPath: ['game', 'dialogs', 'greet'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }
@@ -117,7 +148,7 @@ describe('NodeDetails', () => {
     sampleGame.handlers = ['start']
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['handlers', 'start'] as NodePath,
+      selectedPath: ['game', 'handlers', 'start'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }
@@ -143,7 +174,7 @@ describe('NodeDetails', () => {
     sampleGame.virtualKeys = ['A']
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['virtualKeys', 'A'] as NodePath,
+      selectedPath: ['game', 'virtualKeys', 'A'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }
@@ -169,7 +200,7 @@ describe('NodeDetails', () => {
     sampleGame.virtualInputs = ['jump']
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['virtualInputs', 'jump'] as NodePath,
+      selectedPath: ['game', 'virtualInputs', 'jump'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }
@@ -195,7 +226,7 @@ describe('NodeDetails', () => {
     sampleGame.languages = { en: ['hello', 'world'] }
     const contextValue = {
       game: sampleGame,
-      selectedPath: ['languages', 'en'] as NodePath,
+      selectedPath: ['game', 'languages', 'en'] as NodePath,
       setSelectedPath: vi.fn(),
       setGame: vi.fn(),
     }


### PR DESCRIPTION
## Summary
- add top-level `game` node in editor tree
- allow editing global title and description when `game` node selected
- document new `game` root node and update tests

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68960daddaec8332b1d6fabfc2f8c611