### PR TITLE
feat(editor): collapse map nodes in tree

### DIFF
--- a/src/editor/components/GameTree.tsx
+++ b/src/editor/components/GameTree.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react'
 import { useEditorContext } from '@editor/context/EditorContext'
 import type { NodePath } from '@editor/context/EditorContext'
+import { isMapData } from '@editor/data/map'
 import type { Game } from '../data/game'
 
 export interface GameTreeViewProps {
@@ -24,6 +25,8 @@ function renderRecord(
       {Object.entries(record).map(([key, value]) => {
         const nextPath = [...path, key]
         const selected = pathsEqual(nextPath, selectedPath)
+        const mapNode =
+          isMapData(value) && path[0] === 'game' && path[1] === 'maps'
         return (
           <li key={key}>
             <button
@@ -33,7 +36,7 @@ function renderRecord(
             >
               {key}
             </button>
-            {renderValue(value, nextPath, onSelect, selectedPath)}
+            {!mapNode && renderValue(value, nextPath, onSelect, selectedPath)}
           </li>
         )
       })}
@@ -80,6 +83,14 @@ function renderValue(
     return renderArray(value, path, onSelect, selectedPath)
   }
   if (typeof value === 'object' && value !== null) {
+    if (
+      isMapData(value) &&
+      path.length === 3 &&
+      path[0] === 'game' &&
+      path[1] === 'maps'
+    ) {
+      return null
+    }
     return renderRecord(value as Record<string, unknown>, path, onSelect, selectedPath)
   }
   return null


### PR DESCRIPTION
## Summary
- treat MapData nodes as leaves in GameTree so maps list once
- keep map selection working to show MapDetails

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68964ce9c4788332adfc4086d66c685e