### PR TITLE
feat: add dialog action handlers

### DIFF
--- a/src/engine/actions/actionHandler.ts
+++ b/src/engine/actions/actionHandler.ts
@@ -2,8 +2,10 @@ import type { Action } from '@loader/data/action'
 import type { IGameEngine } from '@engine/core/gameEngine'
 import type { Message } from '@utils/types'
 
-export interface IActionHandler {
-    readonly type: Action['type']
-    handle(engine: IGameEngine, action: Action, message?: Message): void
+export type BaseAction = { type: string }
+
+export interface IActionHandler<T extends BaseAction = Action> {
+    readonly type: T['type']
+    handle(engine: IGameEngine, action: T, message?: Message): void
 }
 

--- a/src/engine/actions/endDialogActionHandler.ts
+++ b/src/engine/actions/endDialogActionHandler.ts
@@ -1,0 +1,20 @@
+import type { IActionHandler } from './actionHandler'
+import type { IGameEngine } from '@engine/core/gameEngine'
+import type { Message } from '@utils/types'
+import type { EndDialogAction } from '@loader/data/dialog'
+
+export class EndDialogActionHandler implements IActionHandler<EndDialogAction> {
+    readonly type = 'end-dialog' as const
+
+    handle(engine: IGameEngine, _action: EndDialogAction, _message?: Message): void {
+        void _action
+        void _message
+        const dialogs = engine.StateManager.state.dialogs
+        if (dialogs.activeDialog) {
+            const state = dialogs.dialogStates[dialogs.activeDialog]
+            if (state) state.activeChoices = []
+        }
+        dialogs.activeDialog = null
+        dialogs.isModalDialog = false
+    }
+}

--- a/src/engine/actions/gotoDialogActionHandler.ts
+++ b/src/engine/actions/gotoDialogActionHandler.ts
@@ -1,0 +1,14 @@
+import type { IActionHandler } from './actionHandler'
+import type { IGameEngine } from '@engine/core/gameEngine'
+import type { Message } from '@utils/types'
+import type { GotoDialogAction } from '@loader/data/dialog'
+import { DIALOG_SHOW_DIALOG } from '@engine/messages/messages'
+
+export class GotoDialogActionHandler implements IActionHandler<GotoDialogAction> {
+    readonly type = 'goto' as const
+
+    handle(engine: IGameEngine, action: GotoDialogAction, _message?: Message): void {
+        void _message
+        engine.MessageBus.postMessage({ message: DIALOG_SHOW_DIALOG, payload: action.target })
+    }
+}

--- a/src/engine/core/gameEngine.ts
+++ b/src/engine/core/gameEngine.ts
@@ -9,7 +9,7 @@ import type { IScriptRunner, ScriptContext } from '../script/scriptRunner'
 import type { Condition } from '@loader/data/condition'
 import type { IOutputManager } from '../output/outputManager'
 import type { ContextData } from './context'
-import type { IActionHandler } from '../actions/actionHandler'
+import type { IActionHandler, BaseAction } from '../actions/actionHandler'
 import type { IConditionResolver } from '../conditions/conditionResolver'
 import type { IHandlerRegistry } from './handlerRegistry'
 import type { ILifecycleManager } from './lifecycleManager'
@@ -21,7 +21,7 @@ export interface IGameEngine {
     cleanup(): void
     executeAction(action: Action): void
     resolveCondition(condition: Condition | null): boolean
-    registerActionHandler(handler: IActionHandler): void
+    registerActionHandler(handler: IActionHandler<BaseAction>): void
     registerConditionResolver(resolver: IConditionResolver): void
     createScriptContext(message?: Message): ScriptContext
     setIsLoading(): void
@@ -69,7 +69,7 @@ export class GameEngine implements IGameEngine {
         this.lifecycleManager.cleanup()
     }
 
-    public registerActionHandler(handler: IActionHandler): void {
+    public registerActionHandler(handler: IActionHandler<BaseAction>): void {
         this.handlerRegistry.registerActionHandler(handler)
     }
 

--- a/src/engine/core/gameEngineInitializer.ts
+++ b/src/engine/core/gameEngineInitializer.ts
@@ -18,7 +18,7 @@ import type { IOutputManager } from '../output/outputManager'
 import type { IDialogManager } from '../dialog/dialogManager'
 import type { ITranslationService } from '../dialog/translationService'
 import type { IScriptRunner } from '../script/scriptRunner'
-import type { IActionHandler } from '../actions/actionHandler'
+import type { IActionHandler, BaseAction } from '../actions/actionHandler'
 import type { IConditionResolver } from '../conditions/conditionResolver'
 import type { Action } from '@loader/data/action'
 import type { Condition } from '@loader/data/condition'
@@ -76,7 +76,7 @@ export interface IEngineManagerFactory {
 }
 
 export interface GameEngineOptions {
-    actionHandlers?: IActionHandler[]
+    actionHandlers?: IActionHandler<BaseAction>[]
     conditionResolvers?: IConditionResolver[]
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import { type IGameEngine } from '@engine/core/gameEngine'
 import { GameEngineInitializer, type IEngineManagerFactory } from '@engine/core/gameEngineInitializer'
 import { PostMessageActionHandler } from '@engine/actions/postMessageActionHandler'
 import { ScriptActionHandler } from '@engine/actions/scriptActionHandler'
+import { GotoDialogActionHandler } from '@engine/actions/gotoDialogActionHandler'
+import { EndDialogActionHandler } from '@engine/actions/endDialogActionHandler'
 import { ScriptConditionResolver } from '@engine/conditions/scriptConditionResolver'
 import { createPageManager } from '@engine/page/pageManagerService'
 import { createMapManager } from '@engine/map/mapManagerService'
@@ -50,7 +52,12 @@ const factory: IEngineManagerFactory = {
 }
 
 const engine: IGameEngine = GameEngineInitializer.initialize(loader, factory, {
-  actionHandlers: [new PostMessageActionHandler(), new ScriptActionHandler()],
+  actionHandlers: [
+    new PostMessageActionHandler(),
+    new ScriptActionHandler(),
+    new GotoDialogActionHandler(),
+    new EndDialogActionHandler()
+  ],
   conditionResolvers: [new ScriptConditionResolver()]
 })
 await engine.start()

--- a/test/engine/dialogActionHandlers.test.ts
+++ b/test/engine/dialogActionHandlers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { HandlerRegistry } from '@engine/core/handlerRegistry'
+import { GameEngine } from '@engine/core/gameEngine'
+import type { EngineContext } from '@engine/core/engineContext'
+import { GotoDialogActionHandler } from '@engine/actions/gotoDialogActionHandler'
+import { EndDialogActionHandler } from '@engine/actions/endDialogActionHandler'
+import { DIALOG_SHOW_DIALOG } from '@engine/messages/messages'
+import type { Message } from '@utils/types'
+import type { GotoDialogAction, EndDialogAction } from '@loader/data/dialog'
+
+function createEngine() {
+  const posted: Message[] = []
+  const messageBus = {
+    registerMessageListener: () => () => {},
+    postMessage: (msg: Message) => { posted.push(msg) },
+    registerNotificationMessage: () => {},
+    shutDown: () => {}
+  }
+  const stateManager = { state: { dialogs: { activeDialog: null, isModalDialog: false, dialogStates: {} } } } as any
+  const handlerRegistry = new HandlerRegistry()
+  const engineContext: EngineContext = {
+    messageBus: messageBus as any,
+    stateManager,
+    translationService: {} as any,
+    inputManager: {} as any,
+    outputManager: {} as any,
+    scriptRunner: {} as any,
+    lifecycleManager: {} as any,
+    handlerRegistry,
+    stateController: { State: { value: 0 }, setIsLoading: () => {}, setIsRunning: () => {} } as any
+  }
+  const engine = new GameEngine(engineContext)
+  return { engine, handlerRegistry, posted, stateManager }
+}
+
+describe('GotoDialogActionHandler', () => {
+  it('posts DIALOG_SHOW_DIALOG with target', () => {
+    const { engine, handlerRegistry, posted } = createEngine()
+    handlerRegistry.registerActionHandler(new GotoDialogActionHandler())
+    const action: GotoDialogAction = { type: 'goto', target: 'next-dialog' }
+    handlerRegistry.executeAction(engine, action)
+    expect(posted).toEqual([{ message: DIALOG_SHOW_DIALOG, payload: 'next-dialog' }])
+  })
+})
+
+describe('EndDialogActionHandler', () => {
+  it('clears dialog state', () => {
+    const { engine, handlerRegistry, stateManager } = createEngine()
+    stateManager.state.dialogs.activeDialog = 'foo'
+    stateManager.state.dialogs.isModalDialog = true
+    stateManager.state.dialogs.dialogStates.foo = { activeChoices: [{ id: 'c1', input: {} as any }] }
+    handlerRegistry.registerActionHandler(new EndDialogActionHandler())
+    const action: EndDialogAction = { type: 'end-dialog' }
+    handlerRegistry.executeAction(engine, action)
+    expect(stateManager.state.dialogs.activeDialog).toBeNull()
+    expect(stateManager.state.dialogs.isModalDialog).toBe(false)
+    expect(stateManager.state.dialogs.dialogStates.foo.activeChoices).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- generalize action handler and registry to support any action type
- add goto and end-dialog handlers to drive dialog flow
- register new dialog handlers in engine startup

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68964e13c5c88332be5d3c421573471a