### PR TITLE
Use React context for GameEngine access

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
-import { GameEngineState, type IGameEngine } from '@engine/core/gameEngine'
+import { GameEngineState } from '@engine/core/gameEngine'
 import { PAGE_SWITCHED_MESSAGE } from '@engine/messages/messages'
 import type { Page as PageData } from '@loader/data/page'
 import { Page } from './controls/page'
+import { useGameEngine } from './engineContext'
 
-export type AppProps = {
-  engine: IGameEngine
-}
-
-export const App: React.FC<AppProps> = ({ engine }): React.JSX.Element => {
+export const App: React.FC = (): React.JSX.Element => {
+  const engine = useGameEngine()
   const engineState = useSyncExternalStore(engine.State.subscribe.bind(engine.State), () => engine.State.value)
   const [activePage, setActivePage] = useState<string | null>(engine.StateManager.state.data.activePage)
   useEffect(() => {
@@ -26,7 +24,7 @@ export const App: React.FC<AppProps> = ({ engine }): React.JSX.Element => {
       return (<div>Loading game data ...</div>)
     case GameEngineState.running:
       return (
-        <Page page={page} engine={engine} />
+        <Page page={page} />
       )
   }
 }

--- a/src/app/components/gameMenu.tsx
+++ b/src/app/components/gameMenu.tsx
@@ -1,13 +1,13 @@
-import type { IGameEngine } from '@engine/core/gameEngine'
 import type { Button } from '@loader/data/button'
 import type { GameMenuComponent } from '@loader/data/component'
+import { useGameEngine } from '@app/engineContext'
 
 export type GameMenuProps = {
     component: GameMenuComponent
-    engine: IGameEngine
 }
 
-export const GameMenu: React.FC<GameMenuProps> = ({ component, engine }): React.JSX.Element => {
+export const GameMenu: React.FC<GameMenuProps> = ({ component }): React.JSX.Element => {
+    const engine = useGameEngine()
 
     const onButtonClick = (button: Button) => {
         engine.executeAction(button.action)

--- a/src/app/components/inputMatrix.tsx
+++ b/src/app/components/inputMatrix.tsx
@@ -1,16 +1,16 @@
 import type { CSSCustomProperties } from '@app/types'
-import type { IGameEngine } from '@engine/core/gameEngine'
 import type { MatrixInputItem } from '@engine/input/inputManager'
 import { INPUTHANDLER_INPUTS_CHANGED, VIRTUAL_INPUT_MESSAGE } from '@engine/messages/messages'
 import type { InputMatrixComponent } from '@loader/data/component'
 import { useEffect, useState } from 'react'
+import { useGameEngine } from '@app/engineContext'
 
 export type InputMatrixProps = {
     component: InputMatrixComponent
-    engine: IGameEngine
 }
 
-export const InputMatrix: React.FC<InputMatrixProps> = ({ component, engine }): React.JSX.Element => {
+export const InputMatrix: React.FC<InputMatrixProps> = ({ component }): React.JSX.Element => {
+    const engine = useGameEngine()
     const [inputMatrix, setInputMatrix] = useState(engine.InputManager.getInputMatrix(component.matrixSize.width, component.matrixSize.height))
     const style: CSSCustomProperties = {
         '--ge-input-matrix-width': component.matrixSize.width.toString(),

--- a/src/app/components/outputLog.tsx
+++ b/src/app/components/outputLog.tsx
@@ -1,15 +1,15 @@
 import { ScrollContainer } from '@app/controls/scrollContainer'
-import type { IGameEngine } from '@engine/core/gameEngine'
 import { OUTPUT_LOG_LINE_ADDED } from '@engine/messages/messages'
 import type { OutputComponent } from '@loader/data/component'
 import { useEffect, useState } from 'react'
+import { useGameEngine } from '@app/engineContext'
 
 export type OutputLogProps = {
     component: OutputComponent
-    engine: IGameEngine
 }
 
-export const OutputLog: React.FC<OutputLogProps> = ({ component, engine }): React.JSX.Element => {
+export const OutputLog: React.FC<OutputLogProps> = ({ component }): React.JSX.Element => {
+    const engine = useGameEngine()
     const [outputLog, setOutputLog] = useState<string>(engine.OutputManager.getLastLines(component.logSize).join(' '))
 
     useEffect(() => {
@@ -17,7 +17,7 @@ export const OutputLog: React.FC<OutputLogProps> = ({ component, engine }): Reac
             setOutputLog(engine.OutputManager.getLastLines(component.logSize).join(' '))
         })
         return cleanup
-    }, [engine])
+    }, [engine, component.logSize])
 
     return (
         <ScrollContainer className='output-log' html={outputLog} />

--- a/src/app/components/squaresMap.tsx
+++ b/src/app/components/squaresMap.tsx
@@ -1,14 +1,13 @@
 import type { CSSCustomProperties } from '@app/types'
-import type { IGameEngine } from '@engine/core/gameEngine'
 import { MAP_SWITCHED_MESSAGE, POSITION_CHANGED_MESSAGE } from '@engine/messages/messages'
 import type { SquaresMapComponent } from '@loader/data/component'
 import type { GameMap } from '@loader/data/map'
 import { useEffect, useState } from 'react'
 import { Tile } from './tile'
+import { useGameEngine } from '@app/engineContext'
 
 export type SquaresMapProps = {
     component: SquaresMapComponent
-    engine: IGameEngine
 }
 
 interface Position {
@@ -16,7 +15,8 @@ interface Position {
     y: number
 }
 
-export const SquaresMap: React.FC<SquaresMapProps> = ({ component, engine }): React.JSX.Element => {
+export const SquaresMap: React.FC<SquaresMapProps> = ({ component }): React.JSX.Element => {
+    const engine = useGameEngine()
     const [activeMap, setActiveMap] = useState<string | null>(engine.StateManager.state.data.location.mapName)
     const [pos, setPos] = useState<Position>(engine.StateManager.state.data.location.position)
 

--- a/src/app/controls/component.tsx
+++ b/src/app/controls/component.tsx
@@ -1,17 +1,15 @@
 import componentRegistry from '@app/components/componentRegistry'
 import type { Component as ComponentData } from '@loader/data/component'
-import type { IGameEngine } from '@engine/core/gameEngine'
 
 export type ComponentProps = {
     component: ComponentData
-    engine: IGameEngine
 }
 
 const DefaultComponent: React.FC<ComponentProps> = ({ component }) => (
     <div>TODO: {component.type}</div>
 )
 
-export const Component:React.FC<ComponentProps> = ({ component, engine }): React.JSX.Element => {
+export const Component:React.FC<ComponentProps> = ({ component }): React.JSX.Element => {
     const ComponentImpl = componentRegistry[component.type] ?? DefaultComponent
-    return <ComponentImpl component={component} engine={engine} />
+    return <ComponentImpl component={component} />
 }

--- a/src/app/controls/page.tsx
+++ b/src/app/controls/page.tsx
@@ -1,15 +1,13 @@
 import type { Page as PageData } from '@loader/data/page'
-import type { IGameEngine } from '@engine/core/gameEngine'
 import { Screen } from './screen'
 
 export type PageProps = {
     page: PageData | null
-    engine: IGameEngine
 }
 
-export const Page: React.FC<PageProps> = ({ page, engine }): React.JSX.Element => {
+export const Page: React.FC<PageProps> = ({ page }): React.JSX.Element => {
     if (page === null) return (<></>)
     return (
-        <Screen screen={page.screen} engine={engine} />
+        <Screen screen={page.screen} />
     )
 }

--- a/src/app/controls/screen.tsx
+++ b/src/app/controls/screen.tsx
@@ -1,14 +1,14 @@
 import type { CSSCustomProperties } from '@app/types'
 import type { Screen as ScreenData } from '@loader/data/page'
-import type { IGameEngine } from '@engine/core/gameEngine'
 import { Component } from './component'
+import { useGameEngine } from '@app/engineContext'
 
 export type ScreenProps = {
     screen: ScreenData
-    engine: IGameEngine
 }
 
-export const Screen: React.FC<ScreenProps> = ({ screen, engine }): React.JSX.Element => {
+export const Screen: React.FC<ScreenProps> = ({ screen }): React.JSX.Element => {
+    const engine = useGameEngine()
     switch (screen.type) {
         case 'grid': {
             const style: CSSCustomProperties = {
@@ -28,7 +28,7 @@ export const Screen: React.FC<ScreenProps> = ({ screen, engine }): React.JSX.Ele
                             }
                             return (
                                 <div className='grid-component' style={componentStyle} key={key}>
-                                    <Component component={item.component} engine={engine} />
+                                    <Component component={item.component} />
                                 </div>
                             )
                         } else return null

--- a/src/app/engineContext.tsx
+++ b/src/app/engineContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { IGameEngine } from '@engine/core/gameEngine'
+
+const GameEngineContext = createContext<IGameEngine | null>(null)
+
+export const GameEngineProvider: React.FC<{ engine: IGameEngine, children: ReactNode }> = ({ engine, children }) => (
+  <GameEngineContext.Provider value={engine}>{children}</GameEngineContext.Provider>
+)
+
+export const useGameEngine = (): IGameEngine => {
+  const engine = useContext(GameEngineContext)
+  if (engine === null) {
+    throw new Error('useGameEngine must be used within a GameEngineProvider')
+  }
+  return engine
+}
+
+export default GameEngineContext

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ import { createDialogManager } from '@engine/dialog/dialogManagerService'
 import { createScriptRunner } from '@engine/script/scriptRunnerFactory'
 import { createTranslationService } from '@engine/dialog/translationServiceFactory'
 import { App } from '@app/app'
+import { GameEngineProvider } from '@app/engineContext'
 import './style/reset.css'
 import './style/variables.css'
 import './style/game.css'
@@ -64,6 +65,10 @@ await engine.start()
 
 const root = document.getElementById('app')
 if (root) {
-  createRoot(root).render(<App engine={engine} />)
+  createRoot(root).render(
+    <GameEngineProvider engine={engine}>
+      <App />
+    </GameEngineProvider>
+  )
 }
 

--- a/test/app/screen.test.tsx
+++ b/test/app/screen.test.tsx
@@ -1,7 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { Screen } from '@app/controls/screen'
+import { describe, it, expect, vi } from 'vitest'
 import type { Screen as ScreenData } from '@loader/data/page'
 import type { IGameEngine } from '@engine/core/gameEngine'
+
+const engine = { resolveCondition: () => true } as unknown as IGameEngine
+vi.mock('@app/engineContext', () => ({ useGameEngine: () => engine }))
+import { Screen } from '@app/controls/screen'
 
 describe('Screen', () => {
   it('applies grid position variables to components', () => {
@@ -17,8 +20,7 @@ describe('Screen', () => {
       ],
     }
 
-    const engine = { resolveCondition: () => true } as unknown as IGameEngine
-    const element = Screen({ screen: screenData, engine }) as React.ReactElement<Record<string, unknown>>
+    const element = Screen({ screen: screenData }) as React.ReactElement<Record<string, unknown>>
     const child = (element.props.children as React.ReactElement<Record<string, unknown>>[])[0]
     const style = child.props.style as Record<string, string>
 


### PR DESCRIPTION
## Summary
- Add `GameEngineContext` provider and `useGameEngine` hook
- Wrap application root with `GameEngineProvider`
- Refactor components to consume engine via hook instead of props

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6896f77a751483329dbaf68b36fd1b52