### PR TITLE
refactor: add context providers for engine services

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -4,18 +4,22 @@ import { PAGE_SWITCHED_MESSAGE } from '@engine/messages/messages'
 import type { Page as PageData } from '@loader/data/page'
 import { Page } from './controls/page'
 import { useGameEngine } from './engineContext'
+import { useMessageBus } from './messageBusContext'
+import { useStateManager } from './stateManagerContext'
 
 export const App: React.FC = (): React.JSX.Element => {
   const engine = useGameEngine()
+  const messageBus = useMessageBus()
+  const stateManager = useStateManager()
   const engineState = useSyncExternalStore(engine.State.subscribe.bind(engine.State), () => engine.State.value)
-  const [activePage, setActivePage] = useState<string | null>(engine.StateManager.state.data.activePage)
+  const [activePage, setActivePage] = useState<string | null>(stateManager.state.data.activePage)
   useEffect(() => {
-    const cleanup = engine.MessageBus.registerMessageListener(PAGE_SWITCHED_MESSAGE, () => {
-      setActivePage(engine.StateManager.state.data.activePage)
+    const cleanup = messageBus.registerMessageListener(PAGE_SWITCHED_MESSAGE, () => {
+      setActivePage(stateManager.state.data.activePage)
     })
     return cleanup
-  }, [engine])
-  const page: PageData | null = activePage !== null ? engine.StateManager.state.pages[activePage] : null
+  }, [messageBus, stateManager])
+  const page: PageData | null = activePage !== null ? stateManager.state.pages[activePage] : null
 
   switch (engineState) {
     case GameEngineState.init:

--- a/src/app/components/gameMenu.tsx
+++ b/src/app/components/gameMenu.tsx
@@ -1,6 +1,7 @@
 import type { Button } from '@loader/data/button'
 import type { GameMenuComponent } from '@loader/data/component'
 import { useGameEngine } from '@app/engineContext'
+import { useTranslationService } from '@app/translationServiceContext'
 
 export type GameMenuProps = {
     component: GameMenuComponent
@@ -8,6 +9,7 @@ export type GameMenuProps = {
 
 export const GameMenu: React.FC<GameMenuProps> = ({ component }): React.JSX.Element => {
     const engine = useGameEngine()
+    const translationService = useTranslationService()
 
     const onButtonClick = (button: Button) => {
         engine.executeAction(button.action)
@@ -17,7 +19,7 @@ export const GameMenu: React.FC<GameMenuProps> = ({ component }): React.JSX.Elem
         <div className='game-menu'>
             {component.buttons.map(button => (
                 <button type='button' key={button.label} onClick={() => onButtonClick(button)}>
-                    {engine.TranslationService.translate(button.label)}
+                    {translationService.translate(button.label)}
                 </button>
             ))}
         </div>

--- a/src/app/components/inputMatrix.tsx
+++ b/src/app/components/inputMatrix.tsx
@@ -3,30 +3,32 @@ import type { MatrixInputItem } from '@engine/input/inputManager'
 import { INPUTHANDLER_INPUTS_CHANGED, VIRTUAL_INPUT_MESSAGE } from '@engine/messages/messages'
 import type { InputMatrixComponent } from '@loader/data/component'
 import { useEffect, useState } from 'react'
-import { useGameEngine } from '@app/engineContext'
+import { useInputManager } from '@app/inputManagerContext'
+import { useMessageBus } from '@app/messageBusContext'
 
 export type InputMatrixProps = {
     component: InputMatrixComponent
 }
 
 export const InputMatrix: React.FC<InputMatrixProps> = ({ component }): React.JSX.Element => {
-    const engine = useGameEngine()
-    const [inputMatrix, setInputMatrix] = useState(engine.InputManager.getInputMatrix(component.matrixSize.width, component.matrixSize.height))
+    const inputManager = useInputManager()
+    const messageBus = useMessageBus()
+    const [inputMatrix, setInputMatrix] = useState(inputManager.getInputMatrix(component.matrixSize.width, component.matrixSize.height))
     const style: CSSCustomProperties = {
         '--ge-input-matrix-width': component.matrixSize.width.toString(),
         '--ge-input-matrix-height': component.matrixSize.height.toString()
     }
 
     useEffect(() => {
-        const cleanup = engine.MessageBus.registerMessageListener(INPUTHANDLER_INPUTS_CHANGED, () => {
-            setInputMatrix(engine.InputManager.getInputMatrix(component.matrixSize.width, component.matrixSize.height))
+        const cleanup = messageBus.registerMessageListener(INPUTHANDLER_INPUTS_CHANGED, () => {
+            setInputMatrix(inputManager.getInputMatrix(component.matrixSize.width, component.matrixSize.height))
         })
         return cleanup
-    }, [engine, component.matrixSize.height, component.matrixSize.width])
+    }, [messageBus, inputManager, component.matrixSize.height, component.matrixSize.width])
 
     const onButtonClick = (item: MatrixInputItem): void => {
         if (!item.enabled || item.virtualInput === '') return
-        engine.MessageBus.postMessage({ message: VIRTUAL_INPUT_MESSAGE, payload: item.virtualInput })
+        messageBus.postMessage({ message: VIRTUAL_INPUT_MESSAGE, payload: item.virtualInput })
     }
 
 

--- a/src/app/components/outputLog.tsx
+++ b/src/app/components/outputLog.tsx
@@ -2,22 +2,24 @@ import { ScrollContainer } from '@app/controls/scrollContainer'
 import { OUTPUT_LOG_LINE_ADDED } from '@engine/messages/messages'
 import type { OutputComponent } from '@loader/data/component'
 import { useEffect, useState } from 'react'
-import { useGameEngine } from '@app/engineContext'
+import { useOutputManager } from '@app/outputManagerContext'
+import { useMessageBus } from '@app/messageBusContext'
 
 export type OutputLogProps = {
     component: OutputComponent
 }
 
 export const OutputLog: React.FC<OutputLogProps> = ({ component }): React.JSX.Element => {
-    const engine = useGameEngine()
-    const [outputLog, setOutputLog] = useState<string>(engine.OutputManager.getLastLines(component.logSize).join(' '))
+    const outputManager = useOutputManager()
+    const messageBus = useMessageBus()
+    const [outputLog, setOutputLog] = useState<string>(outputManager.getLastLines(component.logSize).join(' '))
 
     useEffect(() => {
-        const cleanup = engine.MessageBus.registerMessageListener(OUTPUT_LOG_LINE_ADDED, () => {
-            setOutputLog(engine.OutputManager.getLastLines(component.logSize).join(' '))
+        const cleanup = messageBus.registerMessageListener(OUTPUT_LOG_LINE_ADDED, () => {
+            setOutputLog(outputManager.getLastLines(component.logSize).join(' '))
         })
         return cleanup
-    }, [engine, component.logSize])
+    }, [messageBus, outputManager, component.logSize])
 
     return (
         <ScrollContainer className='output-log' html={outputLog} />

--- a/src/app/inputManagerContext.tsx
+++ b/src/app/inputManagerContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { IInputManager } from '@engine/input/inputManager'
+
+const InputManagerContext = createContext<IInputManager | null>(null)
+
+export const InputManagerProvider: React.FC<{ inputManager: IInputManager, children: ReactNode }> = ({ inputManager, children }) => (
+  <InputManagerContext.Provider value={inputManager}>{children}</InputManagerContext.Provider>
+)
+
+export const useInputManager = (): IInputManager => {
+  const inputManager = useContext(InputManagerContext)
+  if (inputManager === null) {
+    throw new Error('useInputManager must be used within an InputManagerProvider')
+  }
+  return inputManager
+}
+
+export default InputManagerContext

--- a/src/app/messageBusContext.tsx
+++ b/src/app/messageBusContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { IMessageBus } from '@utils/messageBus'
+
+const MessageBusContext = createContext<IMessageBus | null>(null)
+
+export const MessageBusProvider: React.FC<{ messageBus: IMessageBus, children: ReactNode }> = ({ messageBus, children }) => (
+  <MessageBusContext.Provider value={messageBus}>{children}</MessageBusContext.Provider>
+)
+
+export const useMessageBus = (): IMessageBus => {
+  const messageBus = useContext(MessageBusContext)
+  if (messageBus === null) {
+    throw new Error('useMessageBus must be used within a MessageBusProvider')
+  }
+  return messageBus
+}
+
+export default MessageBusContext

--- a/src/app/outputManagerContext.tsx
+++ b/src/app/outputManagerContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { IOutputManager } from '@engine/output/outputManager'
+
+const OutputManagerContext = createContext<IOutputManager | null>(null)
+
+export const OutputManagerProvider: React.FC<{ outputManager: IOutputManager, children: ReactNode }> = ({ outputManager, children }) => (
+  <OutputManagerContext.Provider value={outputManager}>{children}</OutputManagerContext.Provider>
+)
+
+export const useOutputManager = (): IOutputManager => {
+  const outputManager = useContext(OutputManagerContext)
+  if (outputManager === null) {
+    throw new Error('useOutputManager must be used within an OutputManagerProvider')
+  }
+  return outputManager
+}
+
+export default OutputManagerContext

--- a/src/app/stateManagerContext.tsx
+++ b/src/app/stateManagerContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { IStateManager } from '@engine/core/stateManager'
+import type { ContextData } from '@engine/core/context'
+
+const StateManagerContext = createContext<IStateManager<ContextData> | null>(null)
+
+export const StateManagerProvider: React.FC<{ stateManager: IStateManager<ContextData>, children: ReactNode }> = ({ stateManager, children }) => (
+  <StateManagerContext.Provider value={stateManager}>{children}</StateManagerContext.Provider>
+)
+
+export const useStateManager = (): IStateManager<ContextData> => {
+  const stateManager = useContext(StateManagerContext)
+  if (stateManager === null) {
+    throw new Error('useStateManager must be used within a StateManagerProvider')
+  }
+  return stateManager
+}
+
+export default StateManagerContext

--- a/src/app/translationServiceContext.tsx
+++ b/src/app/translationServiceContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext, type ReactNode } from 'react'
+import type { ITranslationService } from '@engine/dialog/translationService'
+
+const TranslationServiceContext = createContext<ITranslationService | null>(null)
+
+export const TranslationServiceProvider: React.FC<{ translationService: ITranslationService, children: ReactNode }> = ({ translationService, children }) => (
+  <TranslationServiceContext.Provider value={translationService}>{children}</TranslationServiceContext.Provider>
+)
+
+export const useTranslationService = (): ITranslationService => {
+  const translationService = useContext(TranslationServiceContext)
+  if (translationService === null) {
+    throw new Error('useTranslationService must be used within a TranslationServiceProvider')
+  }
+  return translationService
+}
+
+export default TranslationServiceContext

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,11 @@ import { createScriptRunner } from '@engine/script/scriptRunnerFactory'
 import { createTranslationService } from '@engine/dialog/translationServiceFactory'
 import { App } from '@app/app'
 import { GameEngineProvider } from '@app/engineContext'
+import { MessageBusProvider } from '@app/messageBusContext'
+import { StateManagerProvider } from '@app/stateManagerContext'
+import { TranslationServiceProvider } from '@app/translationServiceContext'
+import { InputManagerProvider } from '@app/inputManagerContext'
+import { OutputManagerProvider } from '@app/outputManagerContext'
 import './style/reset.css'
 import './style/variables.css'
 import './style/game.css'
@@ -67,7 +72,17 @@ const root = document.getElementById('app')
 if (root) {
   createRoot(root).render(
     <GameEngineProvider engine={engine}>
-      <App />
+      <MessageBusProvider messageBus={engine.MessageBus}>
+        <StateManagerProvider stateManager={engine.StateManager}>
+          <TranslationServiceProvider translationService={engine.TranslationService}>
+            <InputManagerProvider inputManager={engine.InputManager}>
+              <OutputManagerProvider outputManager={engine.OutputManager}>
+                <App />
+              </OutputManagerProvider>
+            </InputManagerProvider>
+          </TranslationServiceProvider>
+        </StateManagerProvider>
+      </MessageBusProvider>
     </GameEngineProvider>
   )
 }


### PR DESCRIPTION
## Summary
- create context providers for message bus, state, translation, input, and output managers
- wrap application root with new providers
- update components to consume context hooks instead of engine props

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6896f9c1613083329dc8b29025a73b07