### PR TITLE
feat(editor): add sidebar tree

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -1,0 +1,23 @@
+# Editor Manual
+
+## Launch the Editor
+
+- macOS/Linux
+  ```bash
+  npm run dev:editor
+  ```
+- Windows PowerShell
+  ```powershell
+  npm run dev:editor
+  ```
+- Windows Command Prompt
+  ```cmd
+  npm run dev:editor
+  ```
+
+This command serves the editor on http://localhost:5174/editor.html.
+
+## Sidebar Tree
+
+When the editor loads, the left side displays a tree. The top node shows the game's title. Underneath are the **pages**, **maps**, **tiles**, and **dialogs** nodes. Each of these nodes lists their respective keys as leaves.
+

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,7 +1,38 @@
+import React, { useEffect, useState } from 'react'
+import { GameTree } from './gameTree'
+
+interface GameData {
+  title: string
+  pages?: Record<string, unknown>
+  maps?: Record<string, unknown>
+  tiles?: Record<string, unknown>
+  dialogs?: Record<string, unknown>
+}
+
 export const App: React.FC = (): React.JSX.Element => {
-    return (
-        <>
-        </>
-    )
+  const [game, setGame] = useState<GameData | null>(null)
+
+  useEffect(() => {
+    fetch('/api/game')
+      .then((res) => res.json())
+      .then((data) => setGame(data))
+      .catch(() => setGame(null))
+  }, [])
+
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div
+        style={{
+          width: '250px',
+          borderRight: '1px solid #ccc',
+          padding: '0.5rem',
+          overflowY: 'auto',
+        }}
+      >
+        <GameTree game={game} />
+      </div>
+      <div style={{ flex: 1 }} />
+    </div>
+  )
 }
 

--- a/src/editor/app/gameTree.tsx
+++ b/src/editor/app/gameTree.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+
+interface GameData {
+  title: string
+  pages?: Record<string, unknown>
+  maps?: Record<string, unknown>
+  tiles?: Record<string, unknown>
+  dialogs?: Record<string, unknown>
+}
+
+interface Section {
+  name: string
+  items: string[]
+}
+
+export const GameTree: React.FC<{ game: GameData | null }> = ({ game }) => {
+  if (!game) {
+    return <div>Loading...</div>
+  }
+
+  const sections: Section[] = [
+    { name: 'pages', items: Object.keys(game.pages || {}) },
+    { name: 'maps', items: Object.keys(game.maps || {}) },
+    { name: 'tiles', items: Object.keys(game.tiles || {}) },
+    { name: 'dialogs', items: Object.keys(game.dialogs || {}) },
+  ]
+
+  return (
+    <ul>
+      <li>
+        {game.title}
+        <ul>
+          {sections.map((section) => (
+            <li key={section.name}>
+              {section.name}
+              <ul>
+                {section.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      </li>
+    </ul>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add GameTree component to display game structure
- fetch game data in editor and show tree in left sidebar
- document editor usage and sidebar tree

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689704ba480483328c67d3a496287a8d