### PR TITLE
refactor(editor): centralize GameData type

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,13 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { GameTree } from './gameTree'
-
-interface GameData {
-  title: string
-  pages?: Record<string, unknown>
-  maps?: Record<string, unknown>
-  tiles?: Record<string, unknown>
-  dialogs?: Record<string, unknown>
-}
+import type { GameData } from '../types'
 
 export const App: React.FC = (): React.JSX.Element => {
   const [game, setGame] = useState<GameData | null>(null)

--- a/src/editor/app/gameTree.tsx
+++ b/src/editor/app/gameTree.tsx
@@ -1,12 +1,5 @@
 import React from 'react'
-
-interface GameData {
-  title: string
-  pages?: Record<string, unknown>
-  maps?: Record<string, unknown>
-  tiles?: Record<string, unknown>
-  dialogs?: Record<string, unknown>
-}
+import type { GameData } from '../types'
 
 interface Section {
   name: string

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -1,0 +1,7 @@
+export interface GameData {
+  title: string
+  pages?: Record<string, unknown>
+  maps?: Record<string, unknown>
+  tiles?: Record<string, unknown>
+  dialogs?: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary
- define shared GameData interface for editor modules
- use GameData interface in app and game tree components

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68970a10818c8332b1ad60d10196cd06