### PR TITLE
feat(editor): add useGameData hook

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,16 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { GameTree } from './gameTree'
-import type { GameData } from '../types'
+import { useGameData } from '../hooks/useGameData'
 
 export const App: React.FC = (): React.JSX.Element => {
-  const [game, setGame] = useState<GameData | null>(null)
-
-  useEffect(() => {
-    fetch('/api/game')
-      .then((res) => res.json())
-      .then((data) => setGame(data))
-      .catch(() => setGame(null))
-  }, [])
+  const game = useGameData()
 
   return (
     <div style={{ display: 'flex', height: '100vh' }}>

--- a/src/editor/hooks/useGameData.ts
+++ b/src/editor/hooks/useGameData.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import type { GameData } from '../types'
+
+export type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+export const useGameData = (fetcher: Fetcher = fetch): GameData | null => {
+  const [game, setGame] = useState<GameData | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    fetcher('/api/game')
+      .then((res) => res.json())
+      .then((data: GameData) => {
+        if (!cancelled) {
+          setGame(data)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setGame(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [fetcher])
+
+  return game
+}
+

--- a/test/editor/useGameData.test.tsx
+++ b/test/editor/useGameData.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+import React, { useEffect, act } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { useGameData, type Fetcher } from '@editor/hooks/useGameData'
+import type { GameData } from '@editor/types'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const TestComponent: React.FC<{ fetcher: Fetcher; onData: (data: GameData | null) => void }> = ({ fetcher, onData }) => {
+  const data = useGameData(fetcher)
+
+  useEffect(() => {
+    onData(data)
+  }, [data, onData])
+
+  return null
+}
+
+describe('useGameData', () => {
+  it('fetches game data using the provided fetcher', async () => {
+    const mockData: GameData = { title: 'Test Game' }
+    const fetcher: Fetcher = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(mockData),
+    } as unknown as Response)
+    const onData = vi.fn()
+
+    const container = document.createElement('div')
+    await act(async () => {
+      createRoot(container).render(<TestComponent fetcher={fetcher} onData={onData} />)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(fetcher).toHaveBeenCalledWith('/api/game')
+    expect(onData).toHaveBeenLastCalledWith(mockData)
+  })
+})
+


### PR DESCRIPTION
## Summary
- encapsulate game data retrieval in a reusable useGameData hook
- refactor editor App to consume useGameData instead of direct fetch calls
- add unit test validating custom fetcher injection

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68970b6325308332b70e607cd1e1ffff