### PR TITLE
feat: edit game metadata in editor

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,9 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { GameTree } from './gameTree'
+import { GameEditor } from './gameEditor'
 import { useGameData } from '../hooks/useGameData'
 
 export const App: React.FC = (): React.JSX.Element => {
   const game = useGameData()
+  const [selected, setSelected] = useState<string | null>(null)
 
   return (
     <div style={{ display: 'flex', height: '100vh' }}>
@@ -15,9 +17,11 @@ export const App: React.FC = (): React.JSX.Element => {
           overflowY: 'auto',
         }}
       >
-        <GameTree game={game} />
+        <GameTree game={game} onSelect={setSelected} />
       </div>
-      <div style={{ flex: 1 }} />
+      <div style={{ flex: 1, padding: '0.5rem', overflowY: 'auto' }}>
+        {selected === 'root' && game ? <GameEditor game={game} /> : null}
+      </div>
     </div>
   )
 }

--- a/src/editor/app/gameEditor.tsx
+++ b/src/editor/app/gameEditor.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react'
+import type { GameData } from '../types'
+
+export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
+  const [title, setTitle] = useState(game.title)
+  const [description, setDescription] = useState(game.description ?? '')
+  const [version, setVersion] = useState(game.version ?? '')
+  const [initialData, setInitialData] = useState(
+    JSON.stringify(game['initial-data'] ?? {}, null, 2)
+  )
+
+  return (
+    <form style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <label>
+        Title
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </label>
+      <label>
+        Description
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </label>
+      <label>
+        Version
+        <input
+          type="text"
+          value={version}
+          onChange={(e) => setVersion(e.target.value)}
+        />
+      </label>
+      <label>
+        Initial Data
+        <textarea
+          value={initialData}
+          onChange={(e) => setInitialData(e.target.value)}
+          style={{ fontFamily: 'monospace' }}
+        />
+      </label>
+    </form>
+  )
+}

--- a/src/editor/app/gameTree.tsx
+++ b/src/editor/app/gameTree.tsx
@@ -6,7 +6,10 @@ interface Section {
   items: string[]
 }
 
-export const GameTree: React.FC<{ game: GameData | null }> = ({ game }) => {
+export const GameTree: React.FC<{ game: GameData | null; onSelect: (node: string) => void }> = ({
+  game,
+  onSelect,
+}) => {
   if (!game) {
     return <div>Loading...</div>
   }
@@ -20,7 +23,7 @@ export const GameTree: React.FC<{ game: GameData | null }> = ({ game }) => {
 
   return (
     <ul>
-      <li>
+      <li onClick={() => onSelect('root')} style={{ cursor: 'pointer' }}>
         {game.title}
         <ul>
           {sections.map((section) => (

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -1,5 +1,8 @@
 export interface GameData {
   title: string
+  description?: string
+  version?: string
+  ['initial-data']?: Record<string, unknown>
   pages?: Record<string, unknown>
   maps?: Record<string, unknown>
   tiles?: Record<string, unknown>


### PR DESCRIPTION
## Summary
- show game.json metadata when root node is selected
- add editor form for title, description, version and initial data

## Testing
- `npm run build`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68970ee29d848332af5ec00c2a9be41f