### PR TITLE
Add page creation form to editor

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -21,3 +21,5 @@ This command serves the editor on http://localhost:5174/editor.html.
 
 When the editor loads, the left side displays a tree. The top node shows the game's title. Underneath are the **pages**, **maps**, **tiles**, and **dialogs** nodes. Each of these nodes lists their respective keys as leaves.
 
+Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its ID and file name. If the file name is left blank, the editor suggests one based on the entered ID (for example, an ID of `intro` results in a suggested file name of `pages/intro.json`).
+

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { GameTree } from './gameTree'
 import { GameEditor } from './gameEditor'
+import { CreatePageForm } from '../pages/createPageForm'
 import { useGameData } from '../hooks/useGameData'
 
 export const App: React.FC = (): React.JSX.Element => {
@@ -21,6 +22,7 @@ export const App: React.FC = (): React.JSX.Element => {
       </div>
       <div style={{ flex: 1, padding: '0.5rem', overflowY: 'auto' }}>
         {selected === 'root' && game ? <GameEditor game={game} /> : null}
+        {selected === 'pages' ? <CreatePageForm /> : null}
       </div>
     </div>
   )

--- a/src/editor/app/gameTree.tsx
+++ b/src/editor/app/gameTree.tsx
@@ -23,12 +23,19 @@ export const GameTree: React.FC<{ game: GameData | null; onSelect: (node: string
 
   return (
     <ul>
-      <li onClick={() => onSelect('root')} style={{ cursor: 'pointer' }}>
-        {game.title}
+      <li>
+        <span onClick={() => onSelect('root')} style={{ cursor: 'pointer' }}>
+          {game.title}
+        </span>
         <ul>
           {sections.map((section) => (
             <li key={section.name}>
-              {section.name}
+              <span
+                onClick={() => onSelect(section.name)}
+                style={{ cursor: 'pointer' }}
+              >
+                {section.name}
+              </span>
               <ul>
                 {section.items.map((item) => (
                   <li key={item}>{item}</li>

--- a/src/editor/pages/createPageForm.tsx
+++ b/src/editor/pages/createPageForm.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from 'react'
+
+export const CreatePageForm: React.FC = () => {
+  const [id, setId] = useState('')
+  const [fileName, setFileName] = useState('')
+  const [fileNameManuallySet, setFileNameManuallySet] = useState(false)
+
+  useEffect(() => {
+    if (!fileNameManuallySet) {
+      setFileName(id ? `pages/${id}.json` : '')
+    }
+  }, [id, fileNameManuallySet])
+
+  const handleFileNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setFileName(value)
+    setFileNameManuallySet(value !== '')
+  }
+
+  return (
+    <form style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <label>
+        Page ID
+        <input type="text" value={id} onChange={(e) => setId(e.target.value)} />
+      </label>
+      <label>
+        File Name
+        <input type="text" value={fileName} onChange={handleFileNameChange} />
+      </label>
+    </form>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Add page creation form that suggests file names based on page IDs
- Enable selecting tree nodes like Pages and Root
- Document page creation form in the editor manual

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689714688f3c8332ae705e68d4608c6d