### PR TITLE
feat(editor): add top bar and form controls

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -23,3 +23,15 @@ When the editor loads, the left side displays a tree. The top node shows the gam
 
 Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its ID and file name. If the file name is left blank, the editor suggests one based on the entered ID (for example, an ID of `intro` results in a suggested file name of `pages/intro.json`).
 
+
+## Top Bar
+
+A bar at the top of the editor displays the current save status and includes a **Save** button.
+
+## Root Page
+
+Selecting the top node in the sidebar shows fields for the title, description, and version. The initial data has been split into separate **Language** and **Start Page** dropdowns.
+
+## Create Page Form
+
+The create page form includes a **Create** button below the fields.

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -7,22 +7,41 @@ import { useGameData } from '../hooks/useGameData'
 export const App: React.FC = (): React.JSX.Element => {
   const game = useGameData()
   const [selected, setSelected] = useState<string | null>(null)
+  const [status, setStatus] = useState('idle')
+
+  const handleSave = (): void => {
+    setStatus('saved')
+  }
 
   return (
-    <div style={{ display: 'flex', height: '100vh' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <div
         style={{
-          width: '250px',
-          borderRight: '1px solid #ccc',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
           padding: '0.5rem',
-          overflowY: 'auto',
+          borderBottom: '1px solid #ccc',
         }}
       >
-        <GameTree game={game} onSelect={setSelected} />
+        <span>Status: {status}</span>
+        <button onClick={handleSave}>Save</button>
       </div>
-      <div style={{ flex: 1, padding: '0.5rem', overflowY: 'auto' }}>
-        {selected === 'root' && game ? <GameEditor game={game} /> : null}
-        {selected === 'pages' ? <CreatePageForm /> : null}
+      <div style={{ display: 'flex', flex: 1 }}>
+        <div
+          style={{
+            width: '250px',
+            borderRight: '1px solid #ccc',
+            padding: '0.5rem',
+            overflowY: 'auto',
+          }}
+        >
+          <GameTree game={game} onSelect={setSelected} />
+        </div>
+        <div style={{ flex: 1, padding: '0.5rem', overflowY: 'auto' }}>
+          {selected === 'root' && game ? <GameEditor game={game} /> : null}
+          {selected === 'pages' ? <CreatePageForm /> : null}
+        </div>
       </div>
     </div>
   )

--- a/src/editor/app/gameEditor.tsx
+++ b/src/editor/app/gameEditor.tsx
@@ -5,9 +5,15 @@ export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
   const [title, setTitle] = useState(game.title)
   const [description, setDescription] = useState(game.description ?? '')
   const [version, setVersion] = useState(game.version ?? '')
-  const [initialData, setInitialData] = useState(
-    JSON.stringify(game['initial-data'] ?? {}, null, 2)
+  const [language, setLanguage] = useState(
+    game['initial-data']?.language ?? ''
   )
+  const [startPage, setStartPage] = useState(
+    game['initial-data']?.['start-page'] ?? ''
+  )
+
+  const languages = Object.keys(game.languages ?? {})
+  const pages = Object.keys(game.pages ?? {})
 
   return (
     <form style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
@@ -35,12 +41,32 @@ export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
         />
       </label>
       <label>
-        Initial Data
-        <textarea
-          value={initialData}
-          onChange={(e) => setInitialData(e.target.value)}
-          style={{ fontFamily: 'monospace' }}
-        />
+        Language
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+        >
+          <option value="">Select language</option>
+          {languages.map((lang) => (
+            <option key={lang} value={lang}>
+              {lang}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Start Page
+        <select
+          value={startPage}
+          onChange={(e) => setStartPage(e.target.value)}
+        >
+          <option value="">Select start page</option>
+          {pages.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
       </label>
     </form>
   )

--- a/src/editor/pages/createPageForm.tsx
+++ b/src/editor/pages/createPageForm.tsx
@@ -27,6 +27,7 @@ export const CreatePageForm: React.FC = () => {
         File Name
         <input type="text" value={fileName} onChange={handleFileNameChange} />
       </label>
+      <button type="button">Create</button>
     </form>
   )
 }

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -2,9 +2,13 @@ export interface GameData {
   title: string
   description?: string
   version?: string
-  ['initial-data']?: Record<string, unknown>
+  ['initial-data']?: {
+    language?: string
+    'start-page'?: string
+  }
   pages?: Record<string, unknown>
   maps?: Record<string, unknown>
   tiles?: Record<string, unknown>
   dialogs?: Record<string, unknown>
+  languages?: Record<string, unknown>
 }

--- a/test/editor/createPageForm.test.tsx
+++ b/test/editor/createPageForm.test.tsx
@@ -1,0 +1,19 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { describe, it, expect } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { CreatePageForm } from '@editor/pages/createPageForm'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('CreatePageForm', () => {
+  it('renders a create button', () => {
+    const container = document.createElement('div')
+    act(() => {
+      createRoot(container).render(<CreatePageForm />)
+    })
+    const button = container.querySelector('button')
+    expect(button).not.toBeNull()
+    expect(button?.textContent).toBe('Create')
+  })
+})

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -1,0 +1,33 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { describe, it, expect } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { GameEditor } from '@editor/app/gameEditor'
+import type { GameData } from '@editor/types'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('GameEditor', () => {
+  it('renders language and start page dropdowns', () => {
+    const game: GameData = {
+      title: 'Test Game',
+      languages: { en: [], fr: [] },
+      pages: { start: 'pages/start.json', other: 'pages/other.json' },
+      ['initial-data']: { language: 'en', 'start-page': 'start' },
+    }
+    const container = document.createElement('div')
+    act(() => {
+      createRoot(container).render(<GameEditor game={game} />)
+    })
+    const selects = container.querySelectorAll('select')
+    expect(selects).toHaveLength(2)
+    const languageSelect = selects[0] as HTMLSelectElement
+    expect(languageSelect.value).toBe('en')
+    const options = Array.from(languageSelect.options).map((o) => o.value)
+    expect(options).toContain('fr')
+    const startPageSelect = selects[1] as HTMLSelectElement
+    expect(startPageSelect.value).toBe('start')
+    const pageOptions = Array.from(startPageSelect.options).map((o) => o.value)
+    expect(pageOptions).toContain('other')
+  })
+})


### PR DESCRIPTION
## Summary
- Add status bar with Save action to editor layout
- Replace raw initial-data JSON with Language and Start Page dropdowns
- Provide Create button in page creation form and update docs

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897325887888332a9b037ce98f84ac0