### PR TITLE
Use CSS modules for editor components

### DIFF
--- a/src/editor/app/app.module.css
+++ b/src/editor/app/app.module.css
@@ -1,0 +1,31 @@
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem;
+  border-bottom: 1px solid #ccc;
+}
+
+.main {
+  display: flex;
+  flex: 1;
+}
+
+.sidebar {
+  width: 250px;
+  border-right: 1px solid #ccc;
+  padding: 0.5rem;
+  overflow-y: auto;
+}
+
+.content {
+  flex: 1;
+  padding: 0.5rem;
+  overflow-y: auto;
+}

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -3,6 +3,7 @@ import { GameTree } from './gameTree'
 import { GameEditor } from './gameEditor'
 import { CreatePageForm } from '../pages/createPageForm'
 import { useGameData } from '../hooks/useGameData'
+import styles from './app.module.css'
 
 export const App: React.FC = (): React.JSX.Element => {
   const game = useGameData()
@@ -14,31 +15,16 @@ export const App: React.FC = (): React.JSX.Element => {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          padding: '0.5rem',
-          borderBottom: '1px solid #ccc',
-        }}
-      >
+    <div className={styles.app}>
+      <div className={styles.header}>
         <span>Status: {status}</span>
         <button onClick={handleSave}>Save</button>
       </div>
-      <div style={{ display: 'flex', flex: 1 }}>
-        <div
-          style={{
-            width: '250px',
-            borderRight: '1px solid #ccc',
-            padding: '0.5rem',
-            overflowY: 'auto',
-          }}
-        >
+      <div className={styles.main}>
+        <div className={styles.sidebar}>
           <GameTree game={game} onSelect={setSelected} />
         </div>
-        <div style={{ flex: 1, padding: '0.5rem', overflowY: 'auto' }}>
+        <div className={styles.content}>
           {selected === 'root' && game ? <GameEditor game={game} /> : null}
           {selected === 'pages' ? <CreatePageForm /> : null}
         </div>

--- a/src/editor/app/gameEditor.module.css
+++ b/src/editor/app/gameEditor.module.css
@@ -1,0 +1,5 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/editor/app/gameEditor.tsx
+++ b/src/editor/app/gameEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import type { GameData } from '../types'
+import styles from './gameEditor.module.css'
 
 export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
   const [title, setTitle] = useState(game.title)
@@ -16,7 +17,7 @@ export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
   const pages = Object.keys(game.pages ?? {})
 
   return (
-    <form style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <form className={styles.form}>
       <label>
         Title
         <input

--- a/src/editor/pages/createPageForm.module.css
+++ b/src/editor/pages/createPageForm.module.css
@@ -1,0 +1,5 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/src/editor/pages/createPageForm.tsx
+++ b/src/editor/pages/createPageForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import styles from './createPageForm.module.css'
 
 export const CreatePageForm: React.FC = () => {
   const [id, setId] = useState('')
@@ -18,7 +19,7 @@ export const CreatePageForm: React.FC = () => {
   }
 
   return (
-    <form style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <form className={styles.form}>
       <label>
         Page ID
         <input type="text" value={id} onChange={(e) => setId(e.target.value)} />

--- a/src/style.d.ts
+++ b/src/style.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: Record<string, string>
+  export default classes
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,11 @@ export default defineConfig({
       },
     },
   },
+  css: {
+    modules: {
+      localsConvention: 'camelCase',
+    },
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:3001',


### PR DESCRIPTION
## Summary
- replace inline editor styling with CSS modules
- configure Vite to support CSS modules

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689737bf09b883328e7985348025e1ec