### PR TITLE
refactor: use onApply for page editing

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,18 +1,38 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { GameTree } from './gameTree'
 import { GameEditor } from './gameEditor'
 import { CreatePageForm } from '../pages/createPageForm'
 import { PageEditor } from '../pages/pageEditor'
 import { useGameData } from '../hooks/useGameData'
+import type { GameData } from '../types'
 import styles from './app.module.css'
 
 export const App: React.FC = (): React.JSX.Element => {
-  const game = useGameData()
+  const fetchedGame = useGameData()
+  const [game, setGame] = useState<GameData | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
   const [status, setStatus] = useState('idle')
 
+  useEffect(() => {
+    if (fetchedGame) {
+      setGame(fetchedGame)
+    }
+  }, [fetchedGame])
+
   const handleSave = (): void => {
     setStatus('saved')
+  }
+
+  const handlePageApply = (page: unknown): void => {
+    if (!game || !selected?.startsWith('pages/')) return
+    const pageId = selected.split('/')[1]
+    setGame({
+      ...game,
+      pages: {
+        ...(game.pages ?? {}),
+        [pageId]: page,
+      },
+    })
   }
 
   return (
@@ -31,6 +51,7 @@ export const App: React.FC = (): React.JSX.Element => {
           {selected?.startsWith('pages/') && game ? (
             <PageEditor
               data={game.pages?.[selected.split('/')[1]]}
+              onApply={handlePageApply}
             />
           ) : null}
         </div>

--- a/src/editor/pages/pageEditor.tsx
+++ b/src/editor/pages/pageEditor.tsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react'
 
-export type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
-
 interface PageEditorProps {
   data: unknown
+  onApply: (data: unknown) => void
 }
 
-export const PageEditor: React.FC<PageEditorProps> = ({ data }) => {
+export const PageEditor: React.FC<PageEditorProps> = ({ data, onApply }) => {
   const [content, setContent] = useState<string>(JSON.stringify(data, null, 2))
+
+  const handleApply = () => {
+    try {
+      onApply(JSON.parse(content))
+    } catch {
+      // Ignore JSON parse errors for now
+    }
+  }
 
   return (
     <div>
@@ -18,7 +25,7 @@ export const PageEditor: React.FC<PageEditorProps> = ({ data }) => {
         cols={80}
       />
       <div>
-        <button>Apply</button>
+        <button onClick={handleApply}>Apply</button>
         <button>Cancel</button>
       </div>
     </div>

--- a/test/editor/pageEditor.test.tsx
+++ b/test/editor/pageEditor.test.tsx
@@ -2,18 +2,18 @@
 import { act } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
-import { PageEditor, type Fetcher } from '@editor/pages/pageEditor'
+import { PageEditor } from '@editor/pages/pageEditor'
 
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 describe('PageEditor', () => {
-  it('posts updates to API endpoint', async () => {
-    const fetcher: Fetcher = vi.fn().mockResolvedValue({} as Response)
+  it('applies updates with parsed JSON data', async () => {
+    const onApply = vi.fn()
     const container = document.createElement('div')
 
     await act(async () => {
       createRoot(container).render(
-        <PageEditor data={{ foo: 'bar' }} />,
+        <PageEditor data={{ foo: 'bar' }} onApply={onApply} />,
       )
     })
 
@@ -22,10 +22,6 @@ describe('PageEditor', () => {
       button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(fetcher).toHaveBeenCalledWith('/api/pages/test', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ foo: 'bar' }, null, 2),
-    })
+    expect(onApply).toHaveBeenCalledWith({ foo: 'bar' })
   })
 })


### PR DESCRIPTION
## Summary
- wire PageEditor to call `onApply` with parsed JSON instead of posting to backend
- update App to handle `onApply` and maintain in-memory game state
- add tests asserting `onApply` is invoked with updated data

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689758e87410833296d9fd24a869d154