### PR TITLE
style: modernize editor appearance

### DIFF
--- a/editor.css
+++ b/editor.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f5f7fa;
+  color: #333;
+}
+
+#app {
+  height: 100vh;
+}
+
+button {
+  background-color: #2563eb;
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #1e4fb7;
+}

--- a/editor.html
+++ b/editor.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Game Editor</title>
+    <link rel="stylesheet" href="/editor.css" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/editor/app/app.module.css
+++ b/src/editor/app/app.module.css
@@ -8,24 +8,29 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem;
-  border-bottom: 1px solid #ccc;
+  padding: 0.75rem 1rem;
+  background-color: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .main {
   display: flex;
   flex: 1;
+  background-color: #f5f7fa;
 }
 
 .sidebar {
   width: 250px;
-  border-right: 1px solid #ccc;
-  padding: 0.5rem;
+  border-right: 1px solid #e5e7eb;
+  background-color: #f0f2f5;
+  padding: 0.75rem;
   overflow-y: auto;
 }
 
 .content {
   flex: 1;
-  padding: 0.5rem;
+  padding: 1rem;
+  background-color: #fff;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- add global editor stylesheet for consistent fonts and button styling
- refresh editor layout with modern header and sidebar colors

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68975f050cb083328e8bbfb60e8f0f63