### PR TITLE
Improve editor form layout

### DIFF
--- a/src/editor/app/gameEditor.module.css
+++ b/src/editor/app/gameEditor.module.css
@@ -1,5 +1,25 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form input,
+.form select,
+.form textarea {
+  width: 20rem;
+  max-width: 100%;
+  padding: 0.25rem;
+}
+
+.form button {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
 }

--- a/src/editor/pages/createPageForm.module.css
+++ b/src/editor/pages/createPageForm.module.css
@@ -1,5 +1,25 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form input,
+.form select,
+.form textarea {
+  width: 20rem;
+  max-width: 100%;
+  padding: 0.25rem;
+}
+
+.form button {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
 }


### PR DESCRIPTION
## Summary
- expand editor form spacing and align items to avoid full-width buttons
- increase input and select control widths with padding for better usability

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689762d16a108332a790a0645a69a314