### PR TITLE
Improve editor tree styling and widen form inputs

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -21,6 +21,8 @@ This command serves the editor on http://localhost:5174/editor.html.
 
 When the editor loads, the left side displays a tree. The top node shows the game's title. Underneath are the **pages**, **maps**, **tiles**, and **dialogs** nodes. Each of these nodes lists their respective keys as leaves.
 
+The tree uses a clean, indented layout with clickable nodes for easier navigation.
+
 Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its ID and file name. If the file name is left blank, the editor suggests one based on the entered ID (for example, an ID of `intro` results in a suggested file name of `pages/intro.json`).
 
 
@@ -31,6 +33,8 @@ A bar at the top of the editor displays the current save status and includes a *
 ## Root Page
 
 Selecting the top node in the sidebar shows fields for the title, description, and version. The initial data has been split into separate **Language** and **Start Page** dropdowns.
+
+Form inputs now provide a wider layout to make editing more comfortable.
 
 ## Create Page Form
 

--- a/src/editor/app/gameEditor.module.css
+++ b/src/editor/app/gameEditor.module.css
@@ -14,7 +14,7 @@
 .form input,
 .form select,
 .form textarea {
-  width: 20rem;
+  width: 30rem;
   max-width: 100%;
   padding: 0.25rem;
 }

--- a/src/editor/app/gameTree.module.css
+++ b/src/editor/app/gameTree.module.css
@@ -1,0 +1,18 @@
+.tree {
+  list-style: none;
+  padding-left: 0;
+}
+
+.tree ul {
+  list-style: none;
+  padding-left: 1rem;
+  margin-left: 0;
+}
+
+.node {
+  cursor: pointer;
+}
+
+.node:hover {
+  text-decoration: underline;
+}

--- a/src/editor/app/gameTree.tsx
+++ b/src/editor/app/gameTree.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { GameData } from '../types'
+import styles from './gameTree.module.css'
 
 interface Section {
   name: string
@@ -22,9 +23,9 @@ export const GameTree: React.FC<{ game: GameData | null; onSelect: (node: string
   ]
 
   return (
-    <ul>
+    <ul className={styles.tree}>
       <li>
-        <span onClick={() => onSelect('root')} style={{ cursor: 'pointer' }}>
+        <span onClick={() => onSelect('root')} className={styles.node}>
           {game.title}
         </span>
         <ul>
@@ -32,7 +33,7 @@ export const GameTree: React.FC<{ game: GameData | null; onSelect: (node: string
             <li key={section.name}>
               <span
                 onClick={() => onSelect(section.name)}
-                style={{ cursor: 'pointer' }}
+                className={styles.node}
               >
                 {section.name}
               </span>
@@ -41,7 +42,7 @@ export const GameTree: React.FC<{ game: GameData | null; onSelect: (node: string
                   <li key={item}>
                     <span
                       onClick={() => onSelect(`${section.name}/${item}`)}
-                      style={{ cursor: 'pointer' }}
+                      className={styles.node}
                     >
                       {item}
                     </span>

--- a/src/editor/pages/createPageForm.module.css
+++ b/src/editor/pages/createPageForm.module.css
@@ -14,7 +14,7 @@
 .form input,
 .form select,
 .form textarea {
-  width: 20rem;
+  width: 30rem;
   max-width: 100%;
   padding: 0.25rem;
 }


### PR DESCRIPTION
## Summary
- style editor sidebar tree with a dedicated CSS module for clearer navigation
- widen form inputs in editor pages to provide more editing space
- document updated tree layout and wider input fields

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689765cfb79c833294a39328bca2e980