### PR TITLE
feat(editor): support dynamic game tree sections

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -19,7 +19,7 @@ This command serves the editor on http://localhost:5174/editor.html.
 
 ## Sidebar Tree
 
-When the editor loads, the left side displays a tree. The top node shows the game's title. Underneath are the **pages**, **maps**, **tiles**, and **dialogs** nodes. Each of these nodes lists their respective keys as leaves.
+When the editor loads, the left side displays a tree. The top node shows the game's title. Below it, the tree lists a section for each data type found in the game (for example, **pages**, **maps**, **tiles**, or **dialogs**). Each section lists its keys as leaves.
 
 The tree uses a clean, indented layout with clickable nodes for easier navigation.
 

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { GameTree } from './gameTree'
+import type { GameTreeSection, GameData } from '../types'
 import { GameEditor } from './gameEditor'
 import { CreatePageForm } from '../pages/createPageForm'
 import { PageEditor } from '../pages/pageEditor'
@@ -7,9 +8,22 @@ import { useGameData } from '../context/GameDataContext'
 import { useSelection } from '../context/SelectionContext'
 import styles from './app.module.css'
 
+export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
+  if (!game) return []
+  const sections: GameTreeSection[] = []
+  if (game.pages) sections.push({ name: 'pages', items: Object.keys(game.pages) })
+  if (game.maps) sections.push({ name: 'maps', items: Object.keys(game.maps) })
+  if (game.tiles) sections.push({ name: 'tiles', items: Object.keys(game.tiles) })
+  if (game.dialogs)
+    sections.push({ name: 'dialogs', items: Object.keys(game.dialogs) })
+  return sections
+}
+
 export const App: React.FC = (): React.JSX.Element => {
   const { game, setGame, status, saveGame } = useGameData()
   const { selected } = useSelection()
+
+  const sections = React.useMemo(() => sectionsFromGame(game), [game])
 
   const handlePageApply = (page: unknown): void => {
     if (!game || !selected?.startsWith('pages/')) return
@@ -38,7 +52,7 @@ export const App: React.FC = (): React.JSX.Element => {
     <div className={styles.app}>
       <div className={styles.main}>
         <div className={styles.sidebar}>
-          <GameTree game={game} />
+          <GameTree game={game} sections={sections} />
         </div>
         <div className={styles.content}>
           <div className={styles.header}>

--- a/src/editor/app/gameTree.tsx
+++ b/src/editor/app/gameTree.tsx
@@ -1,25 +1,16 @@
 import React from 'react'
-import type { GameData } from '../types'
+import type { GameData, GameTreeSection } from '../types'
 import { useSelection } from '../context/SelectionContext'
 import styles from './gameTree.module.css'
 
-interface Section {
-  name: string
-  items: string[]
-}
-
-export const GameTree: React.FC<{ game: GameData | null }> = ({ game }) => {
+export const GameTree: React.FC<{ game: GameData | null; sections: GameTreeSection[] }> = ({
+  game,
+  sections,
+}) => {
   const { setSelected } = useSelection()
   if (!game) {
     return <div>Loading...</div>
   }
-
-  const sections: Section[] = [
-    { name: 'pages', items: Object.keys(game.pages || {}) },
-    { name: 'maps', items: Object.keys(game.maps || {}) },
-    { name: 'tiles', items: Object.keys(game.tiles || {}) },
-    { name: 'dialogs', items: Object.keys(game.dialogs || {}) },
-  ]
 
   return (
     <ul className={styles.tree}>

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -12,3 +12,8 @@ export interface GameData {
   dialogs?: Record<string, unknown>
   languages?: Record<string, unknown>
 }
+
+export interface GameTreeSection {
+  name: string
+  items: string[]
+}

--- a/test/editor/appSections.test.ts
+++ b/test/editor/appSections.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { sectionsFromGame } from '@editor/app/app'
+import type { GameData } from '@editor/types'
+
+describe('sectionsFromGame', () => {
+  it('returns sections for defined keys', () => {
+    const game: GameData = {
+      title: 'Test',
+      pages: { start: {} },
+      tiles: {},
+    }
+    const sections = sectionsFromGame(game)
+    const names = sections.map((s) => s.name)
+    expect(names).toContain('pages')
+    expect(names).toContain('tiles')
+    expect(names).not.toContain('maps')
+  })
+})

--- a/test/editor/gameTree.test.tsx
+++ b/test/editor/gameTree.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { describe, it, expect } from 'vitest'
+import { createRoot } from 'react-dom/client'
+import { GameTree } from '@editor/app/gameTree'
+import type { GameData, GameTreeSection } from '@editor/types'
+import { SelectionProvider } from '@editor/context/SelectionContext'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+describe('GameTree', () => {
+  it('renders provided sections and items', () => {
+    const game: GameData = { title: 'Test Game' }
+    const sections: GameTreeSection[] = [{ name: 'pages', items: ['start'] }]
+    const container = document.createElement('div')
+    act(() => {
+      createRoot(container).render(
+        <SelectionProvider>
+          <GameTree game={game} sections={sections} />
+        </SelectionProvider>
+      )
+    })
+    const spanTexts = Array.from(container.querySelectorAll('span')).map(
+      (n) => n.textContent
+    )
+    expect(spanTexts).toContain('pages')
+    expect(spanTexts).toContain('start')
+    expect(spanTexts).not.toContain('maps')
+  })
+})


### PR DESCRIPTION
## Summary
- add `GameTreeSection` type and pass sections into `GameTree`
- compute sections from `GameData` in `App`
- document and test dynamic sidebar sections

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689782b16ef08332888995b55753d6d2