### PR TITLE
Allow passing extra data with actions

### DIFF
--- a/src/engine/actions/actionHandler.ts
+++ b/src/engine/actions/actionHandler.ts
@@ -5,6 +5,6 @@ import type { Message } from '@utils/types'
 
 export interface IActionHandler<T extends BaseAction = Action> {
     readonly type: T['type']
-    handle(engine: IGameEngine, action: T, message?: Message): void
+    handle(engine: IGameEngine, action: T, message?: Message, data?: unknown): void
 }
 

--- a/src/engine/actions/endDialogActionHandler.ts
+++ b/src/engine/actions/endDialogActionHandler.ts
@@ -7,8 +7,9 @@ import { ADD_LINE_TO_OUTPUT_LOG } from '@engine/messages/messages'
 export class EndDialogActionHandler implements IActionHandler<EndDialogAction> {
     readonly type = 'end-dialog' as const
 
-    handle(engine: IGameEngine, action: EndDialogAction, _message?: Message): void {
+    handle(engine: IGameEngine, action: EndDialogAction, _message?: Message, _data?: unknown): void {
         void _message
+        void _data
         if (action.message) {
             engine.MessageBus.postMessage({
                 message: ADD_LINE_TO_OUTPUT_LOG,

--- a/src/engine/actions/gotoDialogActionHandler.ts
+++ b/src/engine/actions/gotoDialogActionHandler.ts
@@ -7,8 +7,9 @@ import { DIALOG_SHOW_DIALOG } from '@engine/messages/messages'
 export class GotoDialogActionHandler implements IActionHandler<GotoDialogAction> {
     readonly type = 'goto' as const
 
-    handle(engine: IGameEngine, action: GotoDialogAction, _message?: Message): void {
+    handle(engine: IGameEngine, action: GotoDialogAction, _message?: Message, _data?: unknown): void {
         void _message
+        void _data
         engine.MessageBus.postMessage({ message: DIALOG_SHOW_DIALOG, payload: action.target })
     }
 }

--- a/src/engine/actions/postMessageActionHandler.ts
+++ b/src/engine/actions/postMessageActionHandler.ts
@@ -6,8 +6,9 @@ import type { Message } from '@utils/types'
 export class PostMessageActionHandler implements IActionHandler {
     readonly type = 'post-message' as const
 
-    handle(engine: IGameEngine, action: Action, _message?: Message): void {
+    handle(engine: IGameEngine, action: Action, _message?: Message, _data?: unknown): void {
         void _message
+        void _data
         const { message, payload } = action as PostMessageAction
         engine.MessageBus.postMessage({ message, payload })
     }

--- a/src/engine/actions/scriptActionHandler.ts
+++ b/src/engine/actions/scriptActionHandler.ts
@@ -6,9 +6,9 @@ import type { Message } from '@utils/types'
 export class ScriptActionHandler implements IActionHandler {
     readonly type = 'script' as const
 
-    handle(engine: IGameEngine, action: Action, message?: Message): void {
+    handle(engine: IGameEngine, action: Action, message?: Message, data?: unknown): void {
         const { script } = action as ScriptAction
-        engine.ScriptRunner.run<void>(script, engine.createScriptContext(message))
+        engine.ScriptRunner.run<void>(script, engine.createScriptContext(message, data))
     }
 }
 

--- a/src/engine/core/gameEngine.ts
+++ b/src/engine/core/gameEngine.ts
@@ -19,11 +19,11 @@ import type { EngineContext } from './engineContext'
 export interface IGameEngine {
     start(): Promise<void>
     cleanup(): void
-    executeAction(action: Action): void
+    executeAction(action: Action, message?: Message, data?: unknown): void
     resolveCondition(condition: Condition | null): boolean
     registerActionHandler(handler: IActionHandler<BaseAction>): void
     registerConditionResolver(resolver: IConditionResolver): void
-    createScriptContext(message?: Message): ScriptContext
+    createScriptContext(message?: Message, data?: unknown): ScriptContext
     setIsLoading(): void
     setIsRunning(): void
     get StateManager(): IStateManager<ContextData>
@@ -77,8 +77,8 @@ export class GameEngine implements IGameEngine {
         this.handlerRegistry.registerConditionResolver(resolver)
     }
 
-    public executeAction(action: Action): void {
-        this.handlerRegistry.executeAction(this, action, undefined)
+    public executeAction(action: Action, message?: Message, data?: unknown): void {
+        this.handlerRegistry.executeAction(this, action, message, data)
     }
 
     public resolveCondition(condition: Condition | null): boolean {
@@ -121,14 +121,15 @@ export class GameEngine implements IGameEngine {
         return this.outputManager
     }
 
-    public createScriptContext(message?: Message): ScriptContext {
+    public createScriptContext(message?: Message, data?: unknown): ScriptContext {
         const context: ScriptContext = {
             state: this.StateManager.state,
             postMessage: (msg: Message) => {
                 this.MessageBus.postMessage(msg)
             },
             triggerMessage: message?.message,
-            triggerPayload: message?.payload
+            triggerPayload: message?.payload,
+            triggerData: data
         }
         return context
     }

--- a/src/engine/core/gameEngineInitializer.ts
+++ b/src/engine/core/gameEngineInitializer.ts
@@ -44,7 +44,7 @@ export interface IEngineManagerFactory {
         mapLoader: IMapLoader,
         tileLoader: ITileLoader,
         translationService: ITranslationService,
-        executeAction: <T extends BaseAction = Action>(action: T, message?: Message) => void,
+        executeAction: <T extends BaseAction = Action>(action: T, message?: Message, data?: unknown) => void,
         setIsLoading: () => void,
         setIsRunning: () => void
     ): IMapManager
@@ -58,7 +58,7 @@ export interface IEngineManagerFactory {
         stateManager: IStateManager<ContextData>,
         translationService: ITranslationService,
         virtualInputHandler: IVirtualInputHandler,
-        executeAction: <T extends BaseAction = Action>(action: T, message?: Message) => void,
+        executeAction: <T extends BaseAction = Action>(action: T, message?: Message, data?: unknown) => void,
         resolveCondition: (condition: Condition | null) => boolean
     ): IInputManager
     createOutputManager(messageBus: IMessageBus): IOutputManager
@@ -154,7 +154,7 @@ export class GameEngineInitializer {
 
         const setIsLoading = () => stateController.setIsLoading()
         const setIsRunning = () => stateController.setIsRunning()
-        const executeAction = <T extends BaseAction = Action>(action: T, message?: Message) => handlerRegistry.executeAction(engine, action, message)
+        const executeAction = <T extends BaseAction = Action>(action: T, message?: Message, data?: unknown) => handlerRegistry.executeAction(engine, action, message, data)
         const resolveCondition = (condition: Condition | null) => handlerRegistry.resolveCondition(engine, condition)
 
         const pageManager = factory.createPageManager(messageBus, stateManager, loader.pageLoader, setIsLoading, setIsRunning)

--- a/src/engine/core/handlerRegistry.ts
+++ b/src/engine/core/handlerRegistry.ts
@@ -12,7 +12,7 @@ import type { BaseAction } from '@loader/data/action'
 export interface IHandlerRegistry {
     registerActionHandler<T extends BaseAction>(handler: IActionHandler<T>): void
     registerConditionResolver(resolver: IConditionResolver): void
-    executeAction<T extends BaseAction>(engine: IGameEngine, action: T, message?: Message): void
+    executeAction<T extends BaseAction>(engine: IGameEngine, action: T, message?: Message, data?: unknown): void
     resolveCondition(engine: IGameEngine, condition: Condition | null): boolean
     registerGameHandlers(engine: IGameEngine, gameLoader: IGameLoader, handlerLoader: IHandlerLoader, messageBus: IMessageBus): Promise<void>
     cleanup(): void
@@ -31,12 +31,12 @@ export class HandlerRegistry implements IHandlerRegistry {
         this.conditionResolvers.set(resolver.type, resolver)
     }
 
-    public executeAction<T extends BaseAction>(engine: IGameEngine, action: T, message?: Message): void {
+    public executeAction<T extends BaseAction>(engine: IGameEngine, action: T, message?: Message, data?: unknown): void {
         const handler = this.actionHandlers.get(action.type) as IActionHandler<T> | undefined
         if (handler === undefined) {
             fatalError('HandlerRegistry', `No action handler for type: ${action.type}`)
         }
-        handler.handle(engine, action, message)
+        handler.handle(engine, action, message, data)
     }
 
     public resolveCondition(engine: IGameEngine, condition: Condition | null): boolean {
@@ -56,7 +56,7 @@ export class HandlerRegistry implements IHandlerRegistry {
             handlers.forEach((handler: Handler) => {
                 const cleanup = messageBus.registerMessageListener(
                     handler.message,
-                    (msg) => this.executeAction(engine, handler.action, msg)
+                    (msg) => this.executeAction(engine, handler.action, msg, undefined)
                 )
                 this.handlerCleanupList.push(cleanup)
             })

--- a/src/engine/input/inputManager.ts
+++ b/src/engine/input/inputManager.ts
@@ -20,7 +20,7 @@ export type InputManagerServices = {
     messageBus: IMessageBus
     inputSourceTracker: InputSourceTracker
     inputMatrixBuilder: InputMatrixBuilder
-    executeAction: <T extends BaseAction = Action>(action: T, message?: Message) => void
+    executeAction: <T extends BaseAction = Action>(action: T, message?: Message, data?: unknown) => void
 }
 
 export class InputManager implements IInputManager {
@@ -56,7 +56,7 @@ export class InputManager implements IInputManager {
     private onInput(input: string): void {
         const inputItem = this.services.inputSourceTracker.getInput(input)
         if (inputItem && inputItem.enabled && inputItem.input.action) {
-            this.services.executeAction(inputItem.input.action, undefined)
+            this.services.executeAction(inputItem.input.action, undefined, inputItem)
         }
     }
 }

--- a/src/engine/input/inputManagerService.ts
+++ b/src/engine/input/inputManagerService.ts
@@ -15,7 +15,7 @@ export function createInputManager(
     stateManager: IStateManager<ContextData>,
     translationService: ITranslationService,
     virtualInputHandler: IVirtualInputHandler,
-    executeAction: <T extends BaseAction = Action>(action: T, message?: Message) => void,
+    executeAction: <T extends BaseAction = Action>(action: T, message?: Message, data?: unknown) => void,
     resolveCondition: (condition: Condition | null) => boolean
 ): IInputManager {
     const inputSourceTracker = new InputSourceTracker({

--- a/src/engine/map/mapManager.ts
+++ b/src/engine/map/mapManager.ts
@@ -18,7 +18,7 @@ export interface IMapManager {
 export type MapManagerServices = {
     messageBus: IMessageBus
     stateManager: IStateManager<ContextData>
-    executeAction: (action: Action, message?: Message) => void
+    executeAction: (action: Action, message?: Message, data?: unknown) => void
     mapLoaderService: IMapLoaderService
     translationService: ITranslationService
 }

--- a/src/engine/map/mapManagerService.ts
+++ b/src/engine/map/mapManagerService.ts
@@ -15,7 +15,7 @@ export function createMapManager(
     mapLoader: IMapLoader,
     tileLoader: ITileLoader,
     translationService: ITranslationService,
-    executeAction: (action: Action, message?: Message) => void,
+    executeAction: (action: Action, message?: Message, data?: unknown) => void,
     setIsLoading: () => void,
     setIsRunning: () => void
 ): IMapManager {

--- a/src/engine/script/scriptRunner.ts
+++ b/src/engine/script/scriptRunner.ts
@@ -10,7 +10,8 @@ export type ScriptContext = {
     state: ContextData,
     postMessage: (message: Message) => void,
     triggerMessage?: string,
-    triggerPayload?: Message['payload']
+    triggerPayload?: Message['payload'],
+    triggerData?: unknown
 }
 
 export class ScriptRunner implements IScriptRunner {

--- a/test/engine/gameEngine.test.ts
+++ b/test/engine/gameEngine.test.ts
@@ -34,11 +34,12 @@ function createEngine() {
       void setIsRunning
       return { initialize: vi.fn(), switchPage: vi.fn(), cleanup: vi.fn() } as any
     },
-    createMapManager: (messageBus, stateManager, mapLoader, tileLoader, executeAction, setIsLoading, setIsRunning) => {
+    createMapManager: (messageBus, stateManager, mapLoader, tileLoader, translationService, executeAction, setIsLoading, setIsRunning) => {
       void messageBus
       void stateManager
       void mapLoader
       void tileLoader
+      void translationService
       void executeAction
       void setIsLoading
       void setIsRunning

--- a/test/engine/inputManager.test.ts
+++ b/test/engine/inputManager.test.ts
@@ -75,12 +75,12 @@ function createInputManager(actionFn = vi.fn()) {
   }
 
   const inputManager = new InputManager(services)
-  return { inputManager, messageBus, actionFn }
+  return { inputManager, messageBus, actionFn, input }
 }
 
 describe('InputManager', () => {
   it('does not invoke handlers after cleanup and reinitialize cycles', () => {
-    const { inputManager, messageBus, actionFn } = createInputManager()
+    const { inputManager, messageBus, actionFn, input } = createInputManager()
 
     inputManager.initialize()
     inputManager.update()
@@ -92,7 +92,11 @@ describe('InputManager', () => {
     inputManager.initialize()
     inputManager.update()
     messageBus.postMessage({ message: VIRTUAL_INPUT_MESSAGE, payload: 'test' })
-    expect(actionFn).toHaveBeenCalledTimes(1)
+    expect(actionFn).toHaveBeenCalledWith(input.action, undefined, {
+      input,
+      enabled: true,
+      visible: true
+    })
 
     inputManager.cleanup()
     messageBus.postMessage({ message: VIRTUAL_INPUT_MESSAGE, payload: 'test' })

--- a/test/engine/scriptActionHandler.test.ts
+++ b/test/engine/scriptActionHandler.test.ts
@@ -46,18 +46,19 @@ function createEngine() {
 }
 
 describe('ScriptActionHandler', () => {
-  it('provides triggering message and payload to script context', () => {
+  it('provides triggering message, payload and data to script context', () => {
     const { engine, handlerRegistry, messageBus } = createEngine()
     let result: any = null
     messageBus.registerMessageListener('RESULT', msg => { result = msg.payload })
     const action: ScriptAction = {
       type: 'script',
-      script: "context.postMessage({ message: 'RESULT', payload: { msg: context.triggerMessage, payload: context.triggerPayload } })"
+      script: "context.postMessage({ message: 'RESULT', payload: { msg: context.triggerMessage, payload: context.triggerPayload, data: context.triggerData } })"
     }
+    const extraData = { bar: 1 }
     messageBus.registerMessageListener('TRIGGER', msg => {
-      handlerRegistry.executeAction(engine, action as Action, msg)
+      handlerRegistry.executeAction(engine, action as Action, msg, extraData)
     })
     messageBus.postMessage({ message: 'TRIGGER', payload: { foo: 42 } })
-    expect(result).toEqual({ msg: 'TRIGGER', payload: { foo: 42 } })
+    expect(result).toEqual({ msg: 'TRIGGER', payload: { foo: 42 }, data: extraData })
   })
 })


### PR DESCRIPTION
## Summary
- allow ExecuteAction to carry optional data along with message
- pass input item as extra data from InputManager
- expose triggerData in script actions and update tests

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68978550b2d88332a311f30308e21456