### PR TITLE
feat(editor): add page type and cancel handling

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { GameTree } from './gameTree'
-import type { GameTreeSection, GameData } from '../types'
+import type { GameTreeSection, GameData, Page } from '../types'
 import { GameEditor } from './gameEditor'
 import { CreatePageForm } from '../pages/createPageForm'
 import { PageEditor } from '../pages/pageEditor'
@@ -21,11 +21,11 @@ export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
 
 export const App: React.FC = (): React.JSX.Element => {
   const { game, setGame, status, saveGame } = useGameData()
-  const { selected } = useSelection()
+  const { selected, setSelected } = useSelection()
 
   const sections = React.useMemo(() => sectionsFromGame(game), [game])
 
-  const handlePageApply = (page: unknown): void => {
+  const handlePageApply = (page: Page): void => {
     if (!game || !selected?.startsWith('pages/')) return
     const pageId = selected.split('/')[1]
     setGame({
@@ -43,9 +43,18 @@ export const App: React.FC = (): React.JSX.Element => {
       ...game,
       pages: {
         ...(game.pages ?? {}),
-        [id]: fileName,
+        [id]: {
+          id,
+          fileName,
+          inputs: [],
+          screen: { type: 'grid', width: 1, height: 1, components: [] },
+        },
       },
     })
+  }
+
+  const handlePageCancel = (): void => {
+    setSelected('pages')
   }
 
   return (
@@ -65,8 +74,9 @@ export const App: React.FC = (): React.JSX.Element => {
           ) : null}
           {selected?.startsWith('pages/') && game ? (
             <PageEditor
-              data={game.pages?.[selected.split('/')[1]]}
+              data={game.pages?.[selected.split('/')[1]] as Page}
               onApply={handlePageApply}
+              onCancel={handlePageCancel}
             />
           ) : null}
         </div>

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -1,3 +1,6 @@
+import type { Page as LoaderPage } from '../loader/schema/page'
+import { pageSchema } from '../loader/schema/page'
+
 export interface GameData {
   title: string
   description?: string
@@ -6,12 +9,15 @@ export interface GameData {
     language?: string
     'start-page'?: string
   }
-  pages?: Record<string, unknown>
+  pages?: Record<string, Page>
   maps?: Record<string, unknown>
   tiles?: Record<string, unknown>
   dialogs?: Record<string, unknown>
   languages?: Record<string, unknown>
 }
+
+export type Page = LoaderPage & { fileName?: string }
+export { pageSchema as PageSchema }
 
 export interface GameTreeSection {
   name: string

--- a/test/editor/appSections.test.ts
+++ b/test/editor/appSections.test.ts
@@ -6,7 +6,13 @@ describe('sectionsFromGame', () => {
   it('returns sections for defined keys', () => {
     const game: GameData = {
       title: 'Test',
-      pages: { start: {} },
+      pages: {
+        start: {
+          id: 'start',
+          inputs: [],
+          screen: { type: 'grid', width: 1, height: 1, components: [] },
+        },
+      },
       tiles: {},
     }
     const sections = sectionsFromGame(game)

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -12,7 +12,20 @@ describe('GameEditor', () => {
     const game: GameData = {
       title: 'Test Game',
       languages: { en: [], fr: [] },
-      pages: { start: 'pages/start.json', other: 'pages/other.json' },
+      pages: {
+        start: {
+          id: 'start',
+          fileName: 'pages/start.json',
+          inputs: [],
+          screen: { type: 'grid', width: 1, height: 1, components: [] },
+        },
+        other: {
+          id: 'other',
+          fileName: 'pages/other.json',
+          inputs: [],
+          screen: { type: 'grid', width: 1, height: 1, components: [] },
+        },
+      },
       ['initial-data']: { language: 'en', 'start-page': 'start' },
     }
     const container = document.createElement('div')

--- a/test/editor/pageEditor.test.tsx
+++ b/test/editor/pageEditor.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
 import { PageEditor } from '@editor/pages/pageEditor'
+import type { Page } from '@editor/types'
 
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -11,9 +12,15 @@ describe('PageEditor', () => {
     const onApply = vi.fn()
     const container = document.createElement('div')
 
+    const page: Page = {
+      id: 'test',
+      fileName: 'pages/test.json',
+      inputs: [],
+      screen: { type: 'grid', width: 1, height: 1, components: [] },
+    }
     await act(async () => {
       createRoot(container).render(
-        <PageEditor data={{ foo: 'bar' }} onApply={onApply} />,
+        <PageEditor data={page} onApply={onApply} />, 
       )
     })
 
@@ -22,6 +29,6 @@ describe('PageEditor', () => {
       button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(onApply).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(onApply).toHaveBeenCalledWith(page)
   })
 })


### PR DESCRIPTION
## Summary
- reuse loader's zod page schema for editor validation
- keep `fileName` metadata outside JSON and preserve it on save
- initialize new pages with a minimal valid grid screen

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689787b142cc8332b86c21ba09ac6675