### PR TITLE
refactor page creation path building and id validation

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -23,7 +23,7 @@ When the editor loads, the left side displays a tree. The top node shows the gam
 
 The tree uses a clean, indented layout with clickable nodes for easier navigation.
 
-Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its ID and file name. If the file name is left blank, the editor suggests one based on the entered ID (for example, an ID of `intro` results in a suggested file name of `pages/intro.json`).
+Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its ID. The editor saves the page using a path derived from that ID (for example, an ID of `intro` becomes `pages/intro.json`).
 
 ## Top Bar
 

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -6,6 +6,7 @@ import { CreatePageForm } from '../pages/createPageForm'
 import { PageEditor } from '../pages/pageEditor'
 import { useGameData } from '../context/GameDataContext'
 import { useSelection } from '../context/SelectionContext'
+import { pagePath } from '../utils/pagePath'
 import styles from './app.module.css'
 
 export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
@@ -37,8 +38,9 @@ export const App: React.FC = (): React.JSX.Element => {
     })
   }
 
-  const handlePageCreate = (id: string, fileName: string): void => {
+  const handlePageCreate = (id: string): void => {
     if (!game) return
+    const fileName = pagePath(id)
     setGame({
       ...game,
       pages: {

--- a/src/editor/pages/createPageForm.module.css
+++ b/src/editor/pages/createPageForm.module.css
@@ -23,3 +23,7 @@
   align-self: flex-start;
   padding: 0.25rem 0.75rem;
 }
+
+.error {
+  color: red;
+}

--- a/src/editor/pages/createPageForm.tsx
+++ b/src/editor/pages/createPageForm.tsx
@@ -1,53 +1,43 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import styles from './createPageForm.module.css'
+import { isValidPageId } from '../utils/pagePath'
 
 interface CreatePageFormProps {
-  onCreate: (id: string, fileName: string) => void
+  onCreate: (id: string) => void
   initialId?: string
-  initialFileName?: string
 }
 
 export const CreatePageForm: React.FC<CreatePageFormProps> = ({
   onCreate,
   initialId = '',
-  initialFileName = '',
 }) => {
   const [id, setId] = useState(initialId)
-  const [fileName, setFileName] = useState(initialFileName)
-  const [fileNameManuallySet, setFileNameManuallySet] = useState(
-    initialFileName !== '',
-  )
-
-  useEffect(() => {
-    if (!fileNameManuallySet) {
-      setFileName(id ? `pages/${id}.json` : '')
-    }
-  }, [id, fileNameManuallySet])
-
-  const handleFileNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value
-    setFileName(value)
-    setFileNameManuallySet(value !== '')
-  }
+  const [error, setError] = useState('')
 
   const handleCreate = (): void => {
-    if (!id || !fileName) return
-    onCreate(id, fileName)
+    if (!id) return
+    if (!isValidPageId(id)) {
+      setError('Page ID may only include letters, numbers, hyphens, or underscores')
+      return
+    }
+    onCreate(id)
     setId('')
-    setFileName('')
-    setFileNameManuallySet(false)
+    setError('')
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const value = e.target.value
+    setId(value)
+    if (error && isValidPageId(value)) setError('')
   }
 
   return (
     <form className={styles.form}>
       <label>
         Page ID
-        <input type="text" value={id} onChange={(e) => setId(e.target.value)} />
+        <input type="text" value={id} onChange={handleChange} />
       </label>
-      <label>
-        File Name
-        <input type="text" value={fileName} onChange={handleFileNameChange} />
-      </label>
+      {error ? <div className={styles.error}>{error}</div> : null}
       <button type="button" onClick={handleCreate}>
         Create
       </button>

--- a/src/editor/utils/pagePath.ts
+++ b/src/editor/utils/pagePath.ts
@@ -1,0 +1,5 @@
+export const pagePath = (id: string): string => `pages/${id}.json`
+
+const PAGE_ID_PATTERN = /^[A-Za-z0-9_-]+$/
+
+export const isValidPageId = (id: string): boolean => PAGE_ID_PATTERN.test(id)

--- a/test/editor/createPageForm.test.tsx
+++ b/test/editor/createPageForm.test.tsx
@@ -18,17 +18,13 @@ describe('CreatePageForm', () => {
     expect(button?.textContent).toBe('Create')
   })
 
-  it('calls onCreate with page id and file name', async () => {
+  it('calls onCreate with page id', async () => {
     const onCreate = vi.fn()
     const container = document.createElement('div')
 
     await act(async () => {
       createRoot(container).render(
-        <CreatePageForm
-          onCreate={onCreate}
-          initialId="test-page"
-          initialFileName="pages/test-page.json"
-        />,
+        <CreatePageForm onCreate={onCreate} initialId="test-page" />, 
       )
     })
 
@@ -37,9 +33,24 @@ describe('CreatePageForm', () => {
       button.click()
     })
 
-    expect(onCreate).toHaveBeenCalledWith(
-      'test-page',
-      'pages/test-page.json',
-    )
+    expect(onCreate).toHaveBeenCalledWith('test-page')
+  })
+
+  it('rejects invalid page ids', async () => {
+    const onCreate = vi.fn()
+    const container = document.createElement('div')
+
+    await act(async () => {
+      createRoot(container).render(
+        <CreatePageForm onCreate={onCreate} initialId="bad/id" />, 
+      )
+    })
+
+    const button = container.querySelector('button') as HTMLButtonElement
+    await act(async () => {
+      button.click()
+    })
+
+    expect(onCreate).not.toHaveBeenCalled()
   })
 })

--- a/test/editor/pagePath.test.ts
+++ b/test/editor/pagePath.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { pagePath, isValidPageId } from '@editor/utils/pagePath'
+
+describe('pagePath utility', () => {
+  it('builds page file path', () => {
+    expect(pagePath('intro')).toBe('pages/intro.json')
+  })
+
+  it('validates page ids', () => {
+    expect(isValidPageId('valid_id-1')).toBe(true)
+    expect(isValidPageId('invalid/id')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- centralize page path construction in `pagePath` utility
- simplify `CreatePageForm` to collect IDs with validation
- use utility in editor `App` and update documentation

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978ccd9e648332a536a752c5e50ec8