### PR TITLE
feat(editor): add game API for saving

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -28,6 +28,8 @@ Selecting the **pages** node opens a form in the right pane that lets you create
 ## Top Bar
 
 A bar at the top of the editor displays the current save status and includes a **Save** button.
+When you click **Save**, the editor POSTs the current game data to `/api/game`.
+The status text updates to show `saving`, `saved`, or `error` based on the result.
 
 ## Root Page
 

--- a/src/editor/README.md
+++ b/src/editor/README.md
@@ -16,3 +16,9 @@ Launch the editor separately from the main development server:
   ```
 
 This command serves the editor on [http://localhost:5174/editor.html](http://localhost:5174/editor.html).
+
+## Saving and Loading
+
+The editor loads game data and persists changes through functions in
+[`src/editor/api/game.ts`](./api/game.ts). The module exposes `loadGame`
+and `saveGame`, which use the Fetch API under the hood.

--- a/src/editor/api/game.ts
+++ b/src/editor/api/game.ts
@@ -1,0 +1,25 @@
+import type { GameData } from '../types'
+
+export type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+export const loadGame = async (fetcher: Fetcher = fetch): Promise<GameData> => {
+  const response = await fetcher('/api/game')
+  if (!response.ok) {
+    throw new Error('Failed to load game')
+  }
+  return await response.json()
+}
+
+export const saveGame = async (
+  game: GameData,
+  fetcher: Fetcher = fetch
+): Promise<void> => {
+  const response = await fetcher('/api/game', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(game),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to save game')
+  }
+}

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -7,6 +7,7 @@ import { PageEditor } from '../pages/pageEditor'
 import { useGameData } from '../context/GameDataContext'
 import { useSelection } from '../context/SelectionContext'
 import { pagePath } from '../utils/pagePath'
+import { saveGame } from '../api/game'
 import styles from './app.module.css'
 
 export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
@@ -21,10 +22,22 @@ export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
 }
 
 export const App: React.FC = (): React.JSX.Element => {
-  const { game, setGame, status, saveGame } = useGameData()
+  const { game, setGame } = useGameData()
   const { selected, setSelected } = useSelection()
+  const [status, setStatus] = React.useState('idle')
 
   const sections = React.useMemo(() => sectionsFromGame(game), [game])
+
+  const handleSave = async (): Promise<void> => {
+    if (!game) return
+    setStatus('saving')
+    try {
+      await saveGame(game)
+      setStatus('saved')
+    } catch {
+      setStatus('error')
+    }
+  }
 
   const handlePageApply = (page: Page): void => {
     if (!game || !selected?.startsWith('pages/')) return
@@ -68,7 +81,7 @@ export const App: React.FC = (): React.JSX.Element => {
         <div className={styles.content}>
           <div className={styles.header}>
             <span>Status: {status}</span>
-            <button onClick={saveGame}>Save</button>
+            <button onClick={handleSave}>Save</button>
           </div>
           {selected === 'root' && game ? <GameEditor game={game} /> : null}
           {selected === 'pages' ? (
@@ -86,4 +99,3 @@ export const App: React.FC = (): React.JSX.Element => {
     </div>
   )
 }
-

--- a/test/editor/gameDataContext.test.tsx
+++ b/test/editor/gameDataContext.test.tsx
@@ -2,7 +2,8 @@
 import React, { useEffect, act } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
-import { GameDataProvider, useGameData, type Fetcher } from '@editor/context/GameDataContext'
+import { GameDataProvider, useGameData } from '@editor/context/GameDataContext'
+import type { Fetcher } from '@editor/api/game'
 import type { GameData } from '@editor/types'
 
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -28,6 +29,7 @@ describe('GameDataProvider', () => {
   it('loads game data and provides it through context', async () => {
     const mockData: GameData = { title: 'Test Game' }
     const fetcher: Fetcher = vi.fn().mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve(mockData),
     } as unknown as Response)
     const onData = vi.fn()
@@ -38,7 +40,7 @@ describe('GameDataProvider', () => {
     })
 
     await act(async () => {
-      await Promise.resolve()
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
     expect(fetcher).toHaveBeenCalledWith('/api/game')


### PR DESCRIPTION
## Summary
- add game API module with `loadGame` and `saveGame`
- refactor GameDataContext to use new API
- wire editor App to save via API and show status
- document API usage and status updates in editor docs

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6897928daf288332922d16e7032d2416