### PR TITLE
Fix game editor not persisting changes

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -83,7 +83,9 @@ export const App: React.FC = (): React.JSX.Element => {
             <span>Status: {status}</span>
             <button onClick={handleSave}>Save</button>
           </div>
-          {selected === 'root' && game ? <GameEditor game={game} /> : null}
+          {selected === 'root' && game ? (
+            <GameEditor game={game} onChange={(g) => setGame(g)} />
+          ) : null}
           {selected === 'pages' ? (
             <CreatePageForm onCreate={handlePageCreate} />
           ) : null}

--- a/src/editor/app/gameEditor.tsx
+++ b/src/editor/app/gameEditor.tsx
@@ -1,51 +1,84 @@
-import React, { useState } from 'react'
+import React from 'react'
 import type { GameData } from '../types'
 import styles from './gameEditor.module.css'
 
-export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
-  const [title, setTitle] = useState(game.title)
-  const [description, setDescription] = useState(game.description ?? '')
-  const [version, setVersion] = useState(game.version ?? '')
-  const [language, setLanguage] = useState(
-    game['initial-data']?.language ?? ''
-  )
-  const [startPage, setStartPage] = useState(
-    game['initial-data']?.['start-page'] ?? ''
-  )
+interface GameEditorProps {
+  game: GameData
+  onChange: (game: GameData) => void
+}
 
+export const GameEditor: React.FC<GameEditorProps> = ({ game, onChange }) => {
   const languages = Object.keys(game.languages ?? {})
   const pages = Object.keys(game.pages ?? {})
+
+  const handleTitleChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    onChange({ ...game, title: e.target.value })
+  }
+
+  const handleDescriptionChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+  ): void => {
+    onChange({ ...game, description: e.target.value })
+  }
+
+  const handleVersionChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    onChange({ ...game, version: e.target.value })
+  }
+
+  const handleLanguageChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ): void => {
+    onChange({
+      ...game,
+      ['initial-data']: {
+        ...(game['initial-data'] ?? {}),
+        language: e.target.value,
+      },
+    })
+  }
+
+  const handleStartPageChange = (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ): void => {
+    onChange({
+      ...game,
+      ['initial-data']: {
+        ...(game['initial-data'] ?? {}),
+        ['start-page']: e.target.value,
+      },
+    })
+  }
 
   return (
     <form className={styles.form}>
       <label>
         Title
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-        />
+        <input type="text" value={game.title} onChange={handleTitleChange} />
       </label>
       <label>
         Description
         <textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          value={game.description ?? ''}
+          onChange={handleDescriptionChange}
         />
       </label>
       <label>
         Version
         <input
           type="text"
-          value={version}
-          onChange={(e) => setVersion(e.target.value)}
+          value={game.version ?? ''}
+          onChange={handleVersionChange}
         />
       </label>
       <label>
         Language
         <select
-          value={language}
-          onChange={(e) => setLanguage(e.target.value)}
+          value={game['initial-data']?.language ?? ''}
+          onChange={handleLanguageChange}
         >
           <option value="">Select language</option>
           {languages.map((lang) => (
@@ -58,8 +91,8 @@ export const GameEditor: React.FC<{ game: GameData }> = ({ game }) => {
       <label>
         Start Page
         <select
-          value={startPage}
-          onChange={(e) => setStartPage(e.target.value)}
+          value={game['initial-data']?.['start-page'] ?? ''}
+          onChange={handleStartPageChange}
         >
           <option value="">Select start page</option>
           {pages.map((p) => (

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act } from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createRoot } from 'react-dom/client'
 import { GameEditor } from '@editor/app/gameEditor'
 import type { GameData } from '@editor/types'
@@ -30,7 +30,9 @@ describe('GameEditor', () => {
     }
     const container = document.createElement('div')
     act(() => {
-      createRoot(container).render(<GameEditor game={game} />)
+      createRoot(container).render(
+        <GameEditor game={game} onChange={() => {}} />,
+      )
     })
     const selects = container.querySelectorAll('select')
     expect(selects).toHaveLength(2)
@@ -42,5 +44,25 @@ describe('GameEditor', () => {
     expect(startPageSelect.value).toBe('start')
     const pageOptions = Array.from(startPageSelect.options).map((o) => o.value)
     expect(pageOptions).toContain('other')
+  })
+
+  it('calls onChange when fields are edited', async () => {
+    const game: GameData = { title: 'T', languages: {}, pages: {} }
+    const onChange = vi.fn()
+    const container = document.createElement('div')
+    await act(async () => {
+      createRoot(container).render(
+        <GameEditor game={game} onChange={onChange} />,
+      )
+    })
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    const propsKey = Object.keys(textarea).find((k) =>
+      k.startsWith('__reactProps'),
+    ) as string
+    const props = (textarea as unknown as Record<string, any>)[propsKey]
+    act(() => {
+      props.onChange({ target: { value: 'New' } })
+    })
+    expect(onChange).toHaveBeenCalledWith({ ...game, description: 'New' })
   })
 })

--- a/test/editor/gameEditor.test.tsx
+++ b/test/editor/gameEditor.test.tsx
@@ -59,7 +59,9 @@ describe('GameEditor', () => {
     const propsKey = Object.keys(textarea).find((k) =>
       k.startsWith('__reactProps'),
     ) as string
-    const props = (textarea as unknown as Record<string, any>)[propsKey]
+    const props = (textarea as unknown as Record<string, unknown>)[propsKey] as {
+      onChange: (e: { target: { value: string } }) => void
+    }
     act(() => {
       props.onChange({ target: { value: 'New' } })
     })


### PR DESCRIPTION
## Summary
- update GameEditor to write changes back to GameData
- allow App to forward game updates to editor
- add regression test for GameEditor updates

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689796ccf3bc8332ac3e61391226812f