### PR TITLE
feat(editor): generate page id from timestamp

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -23,7 +23,7 @@ When the editor loads, the left side displays a tree. The top node shows the gam
 
 The tree uses a clean, indented layout with clickable nodes for easier navigation.
 
-Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its ID. The editor saves the page using a path derived from that ID (for example, an ID of `intro` becomes `pages/intro.json`).
+Selecting the **pages** node opens a form in the right pane that lets you create a new page by specifying its base name. The editor saves the page using a path derived from that name (for example, a name of `intro` becomes `pages/intro.json`) and automatically appends a timestamp to generate the page's internal ID.
 
 ## Top Bar
 

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -6,7 +6,7 @@ import { CreatePageForm } from '../pages/createPageForm'
 import { PageEditor } from '../pages/pageEditor'
 import { useGameData } from '../context/GameDataContext'
 import { useSelection } from '../context/SelectionContext'
-import { pagePath } from '../utils/pagePath'
+import { pagePath, generatePageId } from '../utils/pagePath'
 import { saveGame } from '../api/game'
 import styles from './app.module.css'
 
@@ -51,14 +51,15 @@ export const App: React.FC = (): React.JSX.Element => {
     })
   }
 
-  const handlePageCreate = (id: string): void => {
+  const handlePageCreate = (baseId: string): void => {
     if (!game) return
-    const fileName = pagePath(id)
+    const fileName = pagePath(baseId)
+    const id = generatePageId(baseId)
     setGame({
       ...game,
       pages: {
         ...(game.pages ?? {}),
-        [id]: {
+        [baseId]: {
           id,
           fileName,
           inputs: [],

--- a/src/editor/utils/pagePath.ts
+++ b/src/editor/utils/pagePath.ts
@@ -3,3 +3,8 @@ export const pagePath = (id: string): string => `pages/${id}.json`
 const PAGE_ID_PATTERN = /^[A-Za-z0-9_-]+$/
 
 export const isValidPageId = (id: string): boolean => PAGE_ID_PATTERN.test(id)
+
+export const generatePageId = (
+  baseName: string,
+  timestamp: () => number = Date.now,
+): string => `${baseName}-${timestamp()}`

--- a/test/editor/pagePath.test.ts
+++ b/test/editor/pagePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { pagePath, isValidPageId } from '@editor/utils/pagePath'
+import { pagePath, isValidPageId, generatePageId } from '@editor/utils/pagePath'
 
 describe('pagePath utility', () => {
   it('builds page file path', () => {
@@ -9,5 +9,10 @@ describe('pagePath utility', () => {
   it('validates page ids', () => {
     expect(isValidPageId('valid_id-1')).toBe(true)
     expect(isValidPageId('invalid/id')).toBe(false)
+  })
+
+  it('generates page ids using timestamp', () => {
+    const fakeNow = () => 123456
+    expect(generatePageId('test', fakeNow)).toBe('test-123456')
   })
 })


### PR DESCRIPTION
## Summary
- derive page's internal id from its file name plus timestamp
- document automatic id generation for new pages
- test and lint improvements

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979f43c4588332ad9da6084e7c0d44