### PR TITLE
Serialize pages before saving game

### DIFF
--- a/src/editor/api/game.ts
+++ b/src/editor/api/game.ts
@@ -1,4 +1,5 @@
 import type { GameData } from '../types'
+import type { Game as LoaderGame } from '../../loader/schema/game'
 
 export type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
@@ -14,10 +15,20 @@ export const saveGame = async (
   game: GameData,
   fetcher: Fetcher = fetch
 ): Promise<void> => {
+  const serialized: LoaderGame = {
+    ...(game as Omit<LoaderGame, 'pages'>),
+    pages: Object.fromEntries(
+      Object.entries(game.pages ?? {}).map(([key, value]) => [
+        key,
+        typeof value === 'string' ? value : value.fileName ?? '',
+      ])
+    ),
+  }
+
   const response = await fetcher('/api/game', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(game),
+    body: JSON.stringify(serialized),
   })
   if (!response.ok) {
     throw new Error('Failed to save game')

--- a/test/editor/saveGame.test.ts
+++ b/test/editor/saveGame.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { saveGame } from '@editor/api/game'
+import type { GameData } from '@editor/types'
+
+const validGame: GameData = {
+  title: 't',
+  description: 'd',
+  version: '1',
+  'initial-data': { language: 'en', 'start-page': 'start-page' },
+  languages: {},
+  pages: {
+    start: {
+      id: 'p',
+      fileName: 'pages/p.json',
+      inputs: [],
+      screen: { type: 'grid', width: 1, height: 1, components: [] },
+    },
+  },
+  maps: {},
+  tiles: {},
+  dialogs: {},
+}
+
+describe('saveGame', () => {
+  it('posts serialized game data', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ ok: true } as Response)
+
+    await saveGame(validGame, fetcher)
+
+    expect(fetcher).toHaveBeenCalledWith('/api/game', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validGame,
+        pages: { start: 'pages/p.json' },
+      }),
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- normalize page objects to file paths when saving game data
- add test to ensure saveGame posts serialized game structure

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ad6ae9d8833283579551d7c36d8f