### PR TITLE
feat(editor): add component-based page editor

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -38,3 +38,11 @@ Selecting the top node in the sidebar shows fields for the title, description, a
 ## Create Page Form
 
 The create page form includes a **Create** button below the fields.
+
+## Page Editor
+
+Choosing a page from the sidebar opens a visual editor. It provides separate
+fields for the page **id**, **inputs**, and **screen**. The **Id** field is a
+text input, while **Inputs** and **Screen** accept JSON and validate against the
+same schemas used by the game loader. Use **Apply** to save changes or
+**Cancel** to discard them.

--- a/src/editor/README.md
+++ b/src/editor/README.md
@@ -22,3 +22,15 @@ This command serves the editor on [http://localhost:5174/editor.html](http://loc
 The editor loads game data and persists changes through functions in
 [`src/editor/api/game.ts`](./api/game.ts). The module exposes `loadGame`
 and `saveGame`, which use the Fetch API under the hood.
+
+## Page Editor
+
+Selecting a page in the sidebar opens a visual editor with dedicated fields for
+the page **id**, **inputs**, and **screen**:
+
+- The **Id** field is a simple text input.
+- The **Inputs** and **Screen** fields accept JSON and validate it against the
+  project's schemas.
+
+Click **Apply** to validate and persist your changes or **Cancel** to revert to
+the original values.

--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -92,6 +92,7 @@ export const App: React.FC = (): React.JSX.Element => {
           ) : null}
           {selected?.startsWith('pages/') && game ? (
             <PageEditor
+              key={selected}
               data={game.pages?.[selected.split('/')[1]] as Page}
               onApply={handlePageApply}
               onCancel={handlePageCancel}

--- a/src/editor/pages/idEditor.tsx
+++ b/src/editor/pages/idEditor.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+
+interface PageIdEditorProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export const PageIdEditor: React.FC<PageIdEditorProps> = ({ value, onChange }) => {
+  const [error, setError] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const id = e.target.value
+    onChange(id)
+    setError(id ? '' : 'Id is required')
+  }
+
+  return (
+    <label>
+      Id
+      <input type="text" value={value} onChange={handleChange} />
+      {error ? <div style={{ color: 'red' }}>{error}</div> : null}
+    </label>
+  )
+}
+

--- a/src/editor/pages/inputsEditor.tsx
+++ b/src/editor/pages/inputsEditor.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import { z } from 'zod'
+import { inputSchema } from '../../loader/schema/inputs'
+import type { Input } from '../../loader/schema/inputs'
+
+const inputsSchema = z.array(inputSchema)
+
+interface InputsEditorProps {
+  value: Input[]
+  onChange: (value: Input[]) => void
+}
+
+export const InputsEditor: React.FC<InputsEditorProps> = ({ value, onChange }) => {
+  const [content, setContent] = useState<string>(JSON.stringify(value, null, 2))
+  const [error, setError] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    const text = e.target.value
+    setContent(text)
+    try {
+      const parsed = JSON.parse(text)
+      const result = inputsSchema.safeParse(parsed)
+      if (result.success) {
+        onChange(result.data)
+        setError('')
+      } else {
+        setError(result.error.issues.map((i) => i.message).join('; '))
+      }
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <label>
+      Inputs
+      <textarea value={content} onChange={handleChange} rows={10} cols={80} />
+      {error ? <div style={{ color: 'red' }}>{error}</div> : null}
+    </label>
+  )
+}
+

--- a/src/editor/pages/pageEditor.tsx
+++ b/src/editor/pages/pageEditor.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react'
 import { pageSchema } from '../../loader/schema/page'
 import type { Page } from '../types'
+import { PageIdEditor } from './idEditor'
+import { InputsEditor } from './inputsEditor'
+import { ScreenEditor } from './screenEditor'
 
 interface PageEditorProps {
   data: Page
@@ -13,56 +16,52 @@ export const PageEditor: React.FC<PageEditorProps> = ({
   onApply,
   onCancel,
 }) => {
-  const initialContent = JSON.stringify(
-    { id: data.id, inputs: data.inputs, screen: data.screen },
-    null,
-    2,
-  )
-  const [content, setContent] = useState<string>(initialContent)
-  const [error, setError] = useState<string>('')
+  const [id, setId] = useState<string>(data.id)
+  const [inputs, setInputs] = useState(data.inputs)
+  const [screen, setScreen] = useState(data.screen)
+  const [error, setError] = useState('')
 
   const handleApply = (): void => {
-    try {
-      const parsed = JSON.parse(content)
-      const result = pageSchema.safeParse(parsed)
-      if (!result.success) {
-        setError(result.error.issues.map((i) => i.message).join('; '))
-        return
-      }
-      setError('')
-      const updated =
-        data.fileName !== undefined
-          ? { ...result.data, fileName: data.fileName }
-          : result.data
-      onApply(updated)
-    } catch (e) {
-      setError((e as Error).message)
+    const result = pageSchema.safeParse({ id, inputs, screen })
+    if (!result.success) {
+      setError(result.error.issues.map((i) => i.message).join('; '))
+      return
     }
+    setError('')
+    const updated =
+      data.fileName !== undefined
+        ? { ...result.data, fileName: data.fileName }
+        : result.data
+    onApply(updated)
   }
 
   const handleCancel = (): void => {
-    setContent(initialContent)
+    setId(data.id)
+    setInputs(data.inputs)
+    setScreen(data.screen)
     setError('')
     onCancel?.()
   }
 
   return (
-    <div>
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        rows={20}
-        cols={80}
-      />
+    <form>
+      <PageIdEditor value={id} onChange={setId} />
+      <InputsEditor value={inputs} onChange={setInputs} />
+      <ScreenEditor value={screen} onChange={setScreen} />
       {error && (
         <pre role="alert" style={{ color: 'red' }}>
           {error}
         </pre>
       )}
       <div>
-        <button onClick={handleApply}>Apply</button>
-        <button onClick={handleCancel}>Cancel</button>
+        <button type="button" onClick={handleApply}>
+          Apply
+        </button>
+        <button type="button" onClick={handleCancel}>
+          Cancel
+        </button>
       </div>
-    </div>
+    </form>
   )
 }
+

--- a/src/editor/pages/screenEditor.tsx
+++ b/src/editor/pages/screenEditor.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import { pageSchema } from '../../loader/schema/page'
+import type { Screen } from '../../loader/schema/page'
+
+const screenSchema = pageSchema.shape.screen
+
+interface ScreenEditorProps {
+  value: Screen
+  onChange: (value: Screen) => void
+}
+
+export const ScreenEditor: React.FC<ScreenEditorProps> = ({ value, onChange }) => {
+  const [content, setContent] = useState<string>(JSON.stringify(value, null, 2))
+  const [error, setError] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    const text = e.target.value
+    setContent(text)
+    try {
+      const parsed = JSON.parse(text)
+      const result = screenSchema.safeParse(parsed)
+      if (result.success) {
+        onChange(result.data)
+        setError('')
+      } else {
+        setError(result.error.issues.map((i) => i.message).join('; '))
+      }
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <label>
+      Screen
+      <textarea value={content} onChange={handleChange} rows={10} cols={80} />
+      {error ? <div style={{ color: 'red' }}>{error}</div> : null}
+    </label>
+  )
+}
+

--- a/test/editor/pageEditor.test.tsx
+++ b/test/editor/pageEditor.test.tsx
@@ -8,7 +8,7 @@ import type { Page } from '@editor/types'
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 describe('PageEditor', () => {
-  it('applies updates with parsed JSON data', async () => {
+  it('applies updates with form data', async () => {
     const onApply = vi.fn()
     const container = document.createElement('div')
 
@@ -20,7 +20,7 @@ describe('PageEditor', () => {
     }
     await act(async () => {
       createRoot(container).render(
-        <PageEditor data={page} onApply={onApply} />, 
+        <PageEditor data={page} onApply={onApply} />,
       )
     })
 


### PR DESCRIPTION
## Summary
- add dedicated Id, Inputs, and Screen editors for pages
- wire PageEditor to use new components with schema validation
- document visual page editor and ensure App resets state on page change

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897be239efc83328600522908becbeb