### PR TITLE
refactor editor app with hooks for saving and page actions

### DIFF
--- a/src/editor/app/app.tsx
+++ b/src/editor/app/app.tsx
@@ -1,77 +1,28 @@
 import React from 'react'
 import { GameTree } from './gameTree'
-import type { GameTreeSection, GameData, Page } from '../types'
+import type { Page } from '../types'
 import { GameEditor } from './gameEditor'
 import { CreatePageForm } from '../pages/createPageForm'
 import { PageEditor } from '../pages/pageEditor'
 import { useGameData } from '../context/GameDataContext'
 import { useSelection } from '../context/SelectionContext'
-import { pagePath, generatePageId } from '../utils/pagePath'
-import { saveGame } from '../api/game'
+import { useGameSaver } from './useGameSaver'
+import { usePageActions } from './usePageActions'
+import { useGameSections } from './useGameSections'
 import styles from './app.module.css'
-
-export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
-  if (!game) return []
-  const sections: GameTreeSection[] = []
-  if (game.pages) sections.push({ name: 'pages', items: Object.keys(game.pages) })
-  if (game.maps) sections.push({ name: 'maps', items: Object.keys(game.maps) })
-  if (game.tiles) sections.push({ name: 'tiles', items: Object.keys(game.tiles) })
-  if (game.dialogs)
-    sections.push({ name: 'dialogs', items: Object.keys(game.dialogs) })
-  return sections
-}
 
 export const App: React.FC = (): React.JSX.Element => {
   const { game, setGame } = useGameData()
   const { selected, setSelected } = useSelection()
-  const [status, setStatus] = React.useState('idle')
 
-  const sections = React.useMemo(() => sectionsFromGame(game), [game])
-
-  const handleSave = async (): Promise<void> => {
-    if (!game) return
-    setStatus('saving')
-    try {
-      await saveGame(game)
-      setStatus('saved')
-    } catch {
-      setStatus('error')
-    }
-  }
-
-  const handlePageApply = (page: Page): void => {
-    if (!game || !selected?.startsWith('pages/')) return
-    const pageId = selected.split('/')[1]
-    setGame({
-      ...game,
-      pages: {
-        ...(game.pages ?? {}),
-        [pageId]: page,
-      },
-    })
-  }
-
-  const handlePageCreate = (baseId: string): void => {
-    if (!game) return
-    const fileName = pagePath(baseId)
-    const id = generatePageId(baseId)
-    setGame({
-      ...game,
-      pages: {
-        ...(game.pages ?? {}),
-        [baseId]: {
-          id,
-          fileName,
-          inputs: [],
-          screen: { type: 'grid', width: 1, height: 1, components: [] },
-        },
-      },
-    })
-  }
-
-  const handlePageCancel = (): void => {
-    setSelected('pages')
-  }
+  const sections = useGameSections(game)
+  const { save, status } = useGameSaver(game)
+  const { apply, create, cancel } = usePageActions(
+    game,
+    setGame,
+    selected,
+    setSelected,
+  )
 
   return (
     <div className={styles.app}>
@@ -82,20 +33,18 @@ export const App: React.FC = (): React.JSX.Element => {
         <div className={styles.content}>
           <div className={styles.header}>
             <span>Status: {status}</span>
-            <button onClick={handleSave}>Save</button>
+            <button onClick={save}>Save</button>
           </div>
           {selected === 'root' && game ? (
             <GameEditor game={game} onChange={(g) => setGame(g)} />
           ) : null}
-          {selected === 'pages' ? (
-            <CreatePageForm onCreate={handlePageCreate} />
-          ) : null}
+          {selected === 'pages' ? <CreatePageForm onCreate={create} /> : null}
           {selected?.startsWith('pages/') && game ? (
             <PageEditor
               key={selected}
               data={game.pages?.[selected.split('/')[1]] as Page}
-              onApply={handlePageApply}
-              onCancel={handlePageCancel}
+              onApply={apply}
+              onCancel={cancel}
             />
           ) : null}
         </div>

--- a/src/editor/app/useGameSaver.ts
+++ b/src/editor/app/useGameSaver.ts
@@ -1,0 +1,35 @@
+import React from 'react'
+import type { GameData } from '../types'
+import { saveGame as defaultSaveGame } from '../api/game'
+
+export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
+export interface UseGameSaverOptions {
+  saver?: (game: GameData) => Promise<void>
+}
+
+export interface GameSaver {
+  save: () => Promise<void>
+  status: SaveStatus
+}
+
+export const useGameSaver = (
+  game: GameData | null,
+  { saver = defaultSaveGame }: UseGameSaverOptions = {}
+): GameSaver => {
+  const [status, setStatus] = React.useState<SaveStatus>('idle')
+
+  const save = React.useCallback(async (): Promise<void> => {
+    if (!game) return
+    setStatus('saving')
+    try {
+      await saver(game)
+      setStatus('saved')
+    } catch {
+      setStatus('error')
+    }
+  }, [game, saver])
+
+  return { save, status }
+}
+

--- a/src/editor/app/useGameSections.ts
+++ b/src/editor/app/useGameSections.ts
@@ -1,0 +1,17 @@
+import React from 'react'
+import type { GameData, GameTreeSection } from '../types'
+
+export const sectionsFromGame = (game: GameData | null): GameTreeSection[] => {
+  if (!game) return []
+  const sections: GameTreeSection[] = []
+  if (game.pages) sections.push({ name: 'pages', items: Object.keys(game.pages) })
+  if (game.maps) sections.push({ name: 'maps', items: Object.keys(game.maps) })
+  if (game.tiles) sections.push({ name: 'tiles', items: Object.keys(game.tiles) })
+  if (game.dialogs)
+    sections.push({ name: 'dialogs', items: Object.keys(game.dialogs) })
+  return sections
+}
+
+export const useGameSections = (game: GameData | null): GameTreeSection[] =>
+  React.useMemo(() => sectionsFromGame(game), [game])
+

--- a/src/editor/app/usePageActions.ts
+++ b/src/editor/app/usePageActions.ts
@@ -1,0 +1,59 @@
+import React from 'react'
+import type { GameData, Page } from '../types'
+import { pagePath, generatePageId } from '../utils/pagePath'
+
+export interface PageActions {
+  apply: (page: Page) => void
+  create: (baseId: string) => void
+  cancel: () => void
+}
+
+export const usePageActions = (
+  game: GameData | null,
+  setGame: (game: GameData) => void,
+  selected: string | null,
+  setSelected: (id: string) => void
+): PageActions => {
+  const apply = React.useCallback(
+    (page: Page): void => {
+      if (!game || !selected?.startsWith('pages/')) return
+      const pageId = selected.split('/')[1]
+      setGame({
+        ...game,
+        pages: {
+          ...(game.pages ?? {}),
+          [pageId]: page,
+        },
+      })
+    },
+    [game, selected, setGame]
+  )
+
+  const create = React.useCallback(
+    (baseId: string): void => {
+      if (!game) return
+      const fileName = pagePath(baseId)
+      const id = generatePageId(baseId)
+      setGame({
+        ...game,
+        pages: {
+          ...(game.pages ?? {}),
+          [baseId]: {
+            id,
+            fileName,
+            inputs: [],
+            screen: { type: 'grid', width: 1, height: 1, components: [] },
+          },
+        },
+      })
+    },
+    [game, setGame]
+  )
+
+  const cancel = React.useCallback((): void => {
+    setSelected('pages')
+  }, [setSelected])
+
+  return { apply, create, cancel }
+}
+

--- a/test/editor/appSections.test.ts
+++ b/test/editor/appSections.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sectionsFromGame } from '@editor/app/app'
+import { sectionsFromGame } from '@editor/app/useGameSections'
 import type { GameData } from '@editor/types'
 
 describe('sectionsFromGame', () => {


### PR DESCRIPTION
## Summary
- extract sectionsFromGame into reusable useGameSections hook
- add useGameSaver and usePageActions hooks for saving and page management
- refactor App to use hooks for cleaner layout composition

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6897d1841a788332b59fe336fc45d1ca