### PR TITLE
feat(editor): add reusable JsonEditor component

### DIFF
--- a/docs/manual-editor.md
+++ b/docs/manual-editor.md
@@ -43,6 +43,6 @@ The create page form includes a **Create** button below the fields.
 
 Choosing a page from the sidebar opens a visual editor. It provides separate
 fields for the page **id**, **inputs**, and **screen**. The **Id** field is a
-text input, while **Inputs** and **Screen** accept JSON and validate against the
-same schemas used by the game loader. Use **Apply** to save changes or
-**Cancel** to discard them.
+text input, while **Inputs** and **Screen** rely on a shared `JsonEditor`
+component to accept JSON and validate against the same schemas used by the game
+loader. Use **Apply** to save changes or **Cancel** to discard them.

--- a/src/editor/README.md
+++ b/src/editor/README.md
@@ -30,7 +30,8 @@ the page **id**, **inputs**, and **screen**:
 
 - The **Id** field is a simple text input.
 - The **Inputs** and **Screen** fields accept JSON and validate it against the
-  project's schemas.
+  project's schemas using the shared [`JsonEditor`](./components/JsonEditor.tsx)
+  component.
 
 Click **Apply** to validate and persist your changes or **Cancel** to revert to
 the original values.

--- a/src/editor/components/JsonEditor.tsx
+++ b/src/editor/components/JsonEditor.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState, type ChangeEvent } from 'react'
+import type { ZodType } from 'zod'
+
+interface JsonEditorProps<T> {
+  value: T
+  schema: ZodType<T>
+  onChange: (value: T) => void
+  label: string
+}
+
+export const JsonEditor = <T,>({ value, schema, onChange, label }: JsonEditorProps<T>) => {
+  const [content, setContent] = useState<string>(JSON.stringify(value, null, 2))
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setContent(JSON.stringify(value, null, 2))
+  }, [value])
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>): void => {
+    const text = e.target.value
+    setContent(text)
+    try {
+      const parsed = JSON.parse(text) as unknown
+      const result = schema.safeParse(parsed)
+      if (result.success) {
+        onChange(result.data)
+        setError('')
+      } else {
+        setError(result.error.issues.map((i) => i.message).join('; '))
+      }
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <label>
+      {label}
+      <textarea value={content} onChange={handleChange} rows={10} cols={80} />
+      {error ? <div style={{ color: 'red' }}>{error}</div> : null}
+    </label>
+  )
+}
+

--- a/src/editor/pages/inputsEditor.tsx
+++ b/src/editor/pages/inputsEditor.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { z } from 'zod'
 import { inputSchema } from '../../loader/schema/inputs'
 import type { Input } from '../../loader/schema/inputs'
+import { JsonEditor } from '../components/JsonEditor'
 
 const inputsSchema = z.array(inputSchema)
 
@@ -10,33 +11,7 @@ interface InputsEditorProps {
   onChange: (value: Input[]) => void
 }
 
-export const InputsEditor: React.FC<InputsEditorProps> = ({ value, onChange }) => {
-  const [content, setContent] = useState<string>(JSON.stringify(value, null, 2))
-  const [error, setError] = useState('')
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
-    const text = e.target.value
-    setContent(text)
-    try {
-      const parsed = JSON.parse(text)
-      const result = inputsSchema.safeParse(parsed)
-      if (result.success) {
-        onChange(result.data)
-        setError('')
-      } else {
-        setError(result.error.issues.map((i) => i.message).join('; '))
-      }
-    } catch (err) {
-      setError((err as Error).message)
-    }
-  }
-
-  return (
-    <label>
-      Inputs
-      <textarea value={content} onChange={handleChange} rows={10} cols={80} />
-      {error ? <div style={{ color: 'red' }}>{error}</div> : null}
-    </label>
-  )
-}
+export const InputsEditor: React.FC<InputsEditorProps> = ({ value, onChange }) => (
+  <JsonEditor value={value} schema={inputsSchema} onChange={onChange} label="Inputs" />
+)
 

--- a/src/editor/pages/screenEditor.tsx
+++ b/src/editor/pages/screenEditor.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { pageSchema } from '../../loader/schema/page'
 import type { Screen } from '../../loader/schema/page'
+import { JsonEditor } from '../components/JsonEditor'
 
 const screenSchema = pageSchema.shape.screen
 
@@ -9,33 +10,7 @@ interface ScreenEditorProps {
   onChange: (value: Screen) => void
 }
 
-export const ScreenEditor: React.FC<ScreenEditorProps> = ({ value, onChange }) => {
-  const [content, setContent] = useState<string>(JSON.stringify(value, null, 2))
-  const [error, setError] = useState('')
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>): void => {
-    const text = e.target.value
-    setContent(text)
-    try {
-      const parsed = JSON.parse(text)
-      const result = screenSchema.safeParse(parsed)
-      if (result.success) {
-        onChange(result.data)
-        setError('')
-      } else {
-        setError(result.error.issues.map((i) => i.message).join('; '))
-      }
-    } catch (err) {
-      setError((err as Error).message)
-    }
-  }
-
-  return (
-    <label>
-      Screen
-      <textarea value={content} onChange={handleChange} rows={10} cols={80} />
-      {error ? <div style={{ color: 'red' }}>{error}</div> : null}
-    </label>
-  )
-}
+export const ScreenEditor: React.FC<ScreenEditorProps> = ({ value, onChange }) => (
+  <JsonEditor value={value} schema={screenSchema} onChange={onChange} label="Screen" />
+)
 


### PR DESCRIPTION
## Summary
- add generic `JsonEditor` component for schema-backed JSON editing
- refactor InputsEditor and ScreenEditor to use JsonEditor
- document shared JsonEditor usage in editor docs

## Testing
- `npm run build`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6897d84da6c883329aee69246162f543