### PR TITLE
refactor: centralize message-driven manager behavior

### DIFF
--- a/src/engine/common/messageDrivenManager.ts
+++ b/src/engine/common/messageDrivenManager.ts
@@ -1,0 +1,22 @@
+import { EventHandlerManager } from './eventHandlerManager'
+import type { IMessageBus } from '@utils/messageBus'
+import type { Message } from '@utils/types'
+
+export abstract class MessageDrivenManager {
+    private eventHandlerManager = new EventHandlerManager()
+
+    protected registerMessageListener(
+        messageBus: IMessageBus,
+        message: string,
+        handler: (message: Message) => void | Promise<void>
+    ): void {
+        this.eventHandlerManager.addListener(
+            messageBus.registerMessageListener(message, handler)
+        )
+    }
+
+    public cleanup(): void {
+        this.eventHandlerManager.clearListeners()
+    }
+}
+

--- a/src/engine/dialog/dialogManager.ts
+++ b/src/engine/dialog/dialogManager.ts
@@ -7,7 +7,7 @@ import type { IDialogLoader } from '@loader/dialogLoader'
 import { loadOnce } from '@utils/loadOnce'
 import { trueCondition, type Condition } from '@loader/data/condition'
 import type { ITranslationService } from './translationService'
-import { EventHandlerManager } from '@engine/common/eventHandlerManager'
+import { MessageDrivenManager } from '@engine/common/messageDrivenManager'
 
 export interface IDialogManager {
     initialize(): void
@@ -24,31 +24,25 @@ export type DialogManagerServices = {
     resolveCondition: (condition: Condition | null) => boolean
 }
 
-export class DialogManager implements IDialogManager {
+export class DialogManager extends MessageDrivenManager implements IDialogManager {
     private services: DialogManagerServices
-    private eventHandlerManager = new EventHandlerManager()
 
     constructor(services: DialogManagerServices) {
+        super()
         this.services = services
     }
 
     public initialize(): void {
-        this.eventHandlerManager.addListener(
-            this.services.messageBus.registerMessageListener(
-                DIALOG_START_DIALOG,
-                async (message) => this.startDialog(message.payload as string)
-            )
+        this.registerMessageListener(
+            this.services.messageBus,
+            DIALOG_START_DIALOG,
+            async (message) => this.startDialog(message.payload as string)
         )
-        this.eventHandlerManager.addListener(
-            this.services.messageBus.registerMessageListener(
-                DIALOG_SHOW_DIALOG,
-                async (message) => this.showDialog(message.payload as string)
-            )
+        this.registerMessageListener(
+            this.services.messageBus,
+            DIALOG_SHOW_DIALOG,
+            async (message) => this.showDialog(message.payload as string)
         )
-    }
-
-    public cleanup(): void {
-        this.eventHandlerManager.clearListeners()
     }
 
     private async startDialog(dialogSetId: string): Promise<void> {

--- a/src/engine/input/inputManager.ts
+++ b/src/engine/input/inputManager.ts
@@ -4,7 +4,7 @@ import type { Action, BaseAction } from '@loader/data/action'
 import type { Message } from '@utils/types'
 import { InputSourceTracker } from './inputSourceTracker'
 import { InputMatrixBuilder, type MatrixInputItem } from './inputMatrixBuilder'
-import { EventHandlerManager } from '@engine/common/eventHandlerManager'
+import { MessageDrivenManager } from '@engine/common/messageDrivenManager'
 
 export type { MatrixInputItem } from './inputMatrixBuilder'
 export { nullMatrixInputItem } from './inputMatrixBuilder'
@@ -23,25 +23,20 @@ export type InputManagerServices = {
     executeAction: <T extends BaseAction = Action>(action: T, message?: Message, data?: unknown) => void
 }
 
-export class InputManager implements IInputManager {
+export class InputManager extends MessageDrivenManager implements IInputManager {
     private services: InputManagerServices
-    private eventHandlerManager = new EventHandlerManager()
 
     constructor(services: InputManagerServices) {
+        super()
         this.services = services
     }
 
     public initialize(): void {
-        this.eventHandlerManager.addListener(
-            this.services.messageBus.registerMessageListener(
-                VIRTUAL_INPUT_MESSAGE,
-                (message) => this.onInput(message.payload as string)
-            )
+        this.registerMessageListener(
+            this.services.messageBus,
+            VIRTUAL_INPUT_MESSAGE,
+            (message) => this.onInput(message.payload as string)
         )
-    }
-
-    public cleanup(): void {
-        this.eventHandlerManager.clearListeners()
     }
 
     public update(): void {

--- a/src/engine/map/mapManager.ts
+++ b/src/engine/map/mapManager.ts
@@ -7,7 +7,7 @@ import type { ChangePositionPayload } from '@engine/messages/types'
 import type { Action } from '@loader/data/action'
 import type { Message } from '@utils/types'
 import type { IMapLoaderService } from './mapLoaderService'
-import { EventHandlerManager } from '@engine/common/eventHandlerManager'
+import { MessageDrivenManager } from '@engine/common/messageDrivenManager'
 import type { ITranslationService } from '@engine/dialog/translationService'
 
 export interface IMapManager {
@@ -23,27 +23,26 @@ export type MapManagerServices = {
     translationService: ITranslationService
 }
 
-export class MapManager implements IMapManager {
-    private eventHandlerManager = new EventHandlerManager()
+export class MapManager extends MessageDrivenManager implements IMapManager {
     private services: MapManagerServices
 
     constructor(services: MapManagerServices) {
+        super()
         this.services = services
     }
 
     public initialize(): void {
         this.services.mapLoaderService.initialize()
-        this.eventHandlerManager.addListener(
-            this.services.messageBus.registerMessageListener(
-                CHANGE_POSITION_MESSAGE,
-                async (message) => this.changePosition(message.payload as unknown as ChangePositionPayload)
-            )
+        this.registerMessageListener(
+            this.services.messageBus,
+            CHANGE_POSITION_MESSAGE,
+            async (message) => this.changePosition(message.payload as unknown as ChangePositionPayload)
         )
     }
 
     public cleanup(): void {
         this.services.mapLoaderService.cleanup()
-        this.eventHandlerManager.clearListeners()
+        super.cleanup()
     }
 
     private async changePosition(position: { x: number; y: number }): Promise<void> {

--- a/src/engine/page/pageManager.ts
+++ b/src/engine/page/pageManager.ts
@@ -5,7 +5,7 @@ import type { IMessageBus } from '@utils/messageBus'
 import type { IStateManager } from '../core/stateManager'
 import type { ContextData } from '../core/context'
 import { PAGE_SWITCHED_MESSAGE, SWITCH_PAGE_MESSAGE } from '../messages/messages'
-import { EventHandlerManager } from '@engine/common/eventHandlerManager'
+import { MessageDrivenManager } from '@engine/common/messageDrivenManager'
 
 export interface IPageManager {
     initialize(): void
@@ -21,25 +21,20 @@ export type PageManagerServices = {
     setIsRunning: () => void
 }
 
-export class PageManager implements IPageManager {
+export class PageManager extends MessageDrivenManager implements IPageManager {
     private services: PageManagerServices
-    private eventHandlerManager = new EventHandlerManager()
 
     constructor(services: PageManagerServices) {
+        super()
         this.services = services
     }
 
     public initialize(): void {
-        this.eventHandlerManager.addListener(
-            this.services.messageBus.registerMessageListener(
-                SWITCH_PAGE_MESSAGE,
-                async (message) => this.switchPage(message.payload as string)
-            )
+        this.registerMessageListener(
+            this.services.messageBus,
+            SWITCH_PAGE_MESSAGE,
+            async (message) => this.switchPage(message.payload as string)
         )
-    }
-
-    public cleanup(): void {
-        this.eventHandlerManager.clearListeners()
     }
 
     public async switchPage(page: string): Promise<void> {

--- a/test/engine/messageDrivenManager.test.ts
+++ b/test/engine/messageDrivenManager.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { MessageDrivenManager } from '@engine/common/messageDrivenManager'
+
+class TestManager extends MessageDrivenManager {
+  private bus: any
+  private handler: (msg: any) => void
+  constructor(bus: any, handler: (msg: any) => void) {
+    super()
+    this.bus = bus
+    this.handler = handler
+  }
+  public initialize(): void {
+    this.registerMessageListener(this.bus, 'TEST', this.handler)
+  }
+}
+
+describe('MessageDrivenManager', () => {
+  it('clears listeners on cleanup', () => {
+    const handlers: ((message: { message: string; payload: unknown }) => void)[] = []
+    const messageBus = {
+      registerMessageListener: vi.fn((_msg: string, handler: (message: { message: string; payload: unknown }) => void) => {
+        handlers.push(handler)
+        return () => {
+          const index = handlers.indexOf(handler)
+          if (index >= 0) handlers.splice(index, 1)
+        }
+      }),
+      postMessage: (message: { message: string; payload: unknown }) => {
+        handlers.forEach(h => h(message))
+      }
+    }
+
+    const fn = vi.fn()
+    const manager = new TestManager(messageBus, fn)
+
+    manager.initialize()
+    messageBus.postMessage({ message: 'TEST', payload: undefined })
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    manager.cleanup()
+    messageBus.postMessage({ message: 'TEST', payload: undefined })
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add MessageDrivenManager to manage message bus listeners
- refactor managers to extend new base
- test cleanup of message-driven managers

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68984d00807c8332bab730b654a2baec